### PR TITLE
Fix /etc/sysconfig/ldap vars values for RedHat

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -55,23 +55,26 @@ class openldap::server::config {
         ensure   => present,
         target   => '/etc/sysconfig/ldap',
         variable => 'SLAPD_LDAP',
-        value    => true,
+        value    => 'yes',
       }
       $slapd_ldaps_ensure = $::openldap::server::ssl ? {
         true  => present,
         false => absent,
       }
       shellvar { 'SLAPD_LDAPS':
-        ensure   => $slapd_ldaps_ensure,
-        target   => '/etc/sysconfig/ldap',
-        variable => 'SLAPD_LDAPS',
-        value    => $::openldap::server::ssl,
+        ensure    => $slapd_ldaps_ensure,
+        target    => '/etc/sysconfig/ldap',
+        variable  => 'SLAPD_LDAPS',
+        value     => $::openldap::server::ssl ? {
+          true    => 'yes',
+          default => 'no',
+        },
       }
       shellvar { 'SLAPD_LDAPI':
         ensure   => present,
         target   => '/etc/sysconfig/ldap',
         variable => 'SLAPD_LDAPI',
-        value    => true,
+        value    => 'yes',
       }
     }
     default: {


### PR DESCRIPTION
The various SLAPD_\* vars need to have a 'yes'/'no' value (currently
true/false)
