### PR TITLE
Several <WHAT> statements can be used

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:openldap_access).provide(:olc) do
         when /^olcSuffix: /
           suffix = line.split(' ')[1]
         when /^olcAccess: /
-          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+)(\s+by\s+.*)+$/).captures
+          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(.+)(\s+by\s+.*)+$/).captures
           bys.split(' by ')[1..-1].each { |b|
             by, access, control = b.strip.match(/^(\S+)\s+(\S+)(\s+\S+)?$/).captures
             i << new(

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -26,7 +26,7 @@ Puppet::Type.newtype(:openldap_access) do
   def self.title_patterns
     [
       [
-        /^(to\s+(\S+)\s+by\s+(.+)\s+on\s+(.+))$/,
+        /^(to\s+(.+)\s+by\s+(.+)\s+on\s+(.+))$/,
         [
           [ :name, lambda{|x| x} ],
           [ :what, lambda{|x| x} ],
@@ -35,7 +35,7 @@ Puppet::Type.newtype(:openldap_access) do
         ],
       ],
       [
-        /^(to\s+(\S+)\s+by\s+(.+))$/,
+        /^(to\s+(.+)\s+by\s+(.+))$/,
         [
           [ :name, lambda{|x| x} ],
           [ :what, lambda{|x| x} ],


### PR DESCRIPTION
Quoting SLAPD.ACCESS(5):

The dn, filter, and attrs statements are additive [..]

Example: to dn.subtree="dc=ldap1,dc=example,dc=org" attrs=userPassword,shadowLastChange by dn.exact="cn=replicator,dc=ldap1,dc=example,dc=org"