### PR TITLE
Updated dependencies for augeasproviders

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,11 +13,11 @@
       "version_requirement": ">=3.2.0 <5.0.0"
     },
     {
-      "name": "domcleal/augeasproviders_core",
+      "name": "herculesteam/augeasproviders_core",
       "version_requirement": ">=2.0.0"
     },
     {
-      "name": "domcleal/augeasproviders_shellvar",
+      "name": "herculesteam/augeasproviders_shellvar",
       "version_requirement": ">=2.0.0"
     }
   ],


### PR DESCRIPTION
See #28.

I've tested this with `librarian-puppet install` and it works.
