### PR TITLE
Openldap_ssha function added

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Resources:
 Functions:
 
 * [openldap\_password](#function-openldappassword)
+* [openldap\_password](#function-openldapssha)
 
 ###Class: openldap::client
 
@@ -298,6 +299,8 @@ Specify a password (or hash of the password) for the rootdn.
 ###Resource: openldap::server::schema
 
 ###Function: openldap_password
+
+###Function: openldap_ssha
 
 Contributors
 ------------

--- a/lib/puppet/parser/functions/openldap_ssha.rb
+++ b/lib/puppet/parser/functions/openldap_ssha.rb
@@ -1,0 +1,8 @@
+require 'digest/sha1'
+require 'base64'
+
+module Puppet::Parser::Functions
+  newfunction(:openldap_ssha, :type => :rvalue) do |args|
+    "{SSHA}"+Base64.encode64(Digest::SHA1.digest(args[0]+'salt')+'salt').chomp!    
+  end
+end


### PR DESCRIPTION
This PR adds function openldap_ssha - which can be used anytime. The problem with default openldap_password() is  - "chicken and egg" - it uses slappasswd utility that comes from slapd package. And because of functions in puppet executing on compile time - this code `rootpw    => openldap_password('mySuperSecretPassword')` will fail with error on pure system:

```puppet
bug: hiera(): Cannot find datafile /var/lib/hiera/common.yaml, skipping
Debug: importing '/etc/puppet/modules/openldap/manifests/server/config.pp' in environment production
Debug: Automatically imported openldap::server::config from openldap/server/config into production
Debug: importing '/etc/puppet/modules/openldap/manifests/server/service.pp' in environment production
Debug: Automatically imported openldap::server::service from openldap/server/service into production
Debug: importing '/etc/puppet/modules/openldap/manifests/server/slapdconf.pp' in environment production
Debug: Automatically imported openldap::server::slapdconf from openldap/server/slapdconf into production
Debug: importing '/etc/puppet/modules/openldap/manifests/server/database.pp' in environment production
Debug: Automatically imported openldap::server::database from openldap/server/database into production
Debug: Executing 'slappasswd -s password'
Error: Execution of 'slappasswd -s password' returned 1: Error: Could not execute posix command: No such file or directory - slappasswd on node ubuntu.kha.mirantis.net
Error: Execution of 'slappasswd -s password' returned 1: Error: Could not execute posix command: No such file or directory - slappasswd on node ubuntu.kha.mirantis.net
```