### PR TITLE
Update olc.rb to slapcat output with wrapped lines

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
       directory = nil
       rootdn = nil
       rootpw = nil
-      paragraph.split("\n").collect do |line|
+      paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
           index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb)$/).captures


### PR DESCRIPTION
Ldif format specifies that lines that are too long be wrapped to the next line and delimited with a leading space.  The proposed fix resolves a bug where lines that do wrap to the next line get truncated.  

The following is an example output that this bugfix resolves:

```
dn: cn=admin,dc=example,dc=com
objectClass: simpleSecurityObject
objectClass: organizationalRole
cn: admin
description: LDAP administrator
userPassword:: e0NSWVBUfSQ2JHJvdW5kcz0yMDAwMCRIV1EyZjl6UjlydHJkYzZJJRHOFJleHox
 YYS54RUZrT1FUZ0FFWGppMnRwWnpxRnYzbUlIcXlia26LbUM3cDFiN05QU3NxTDZmcHEczMy52Z1R
 b1g4VWhVa0FuYnNaeGpEYUZhRlYv
```

The proposed solution removes new lines followed by spaces effectively joining the last 3 lines in the example provided.