### PR TITLE
Fix Ubuntu detection for default backend

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -119,6 +119,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
     t = Tempfile.new('openldap_database')
     t << "dn: olcDatabase=#{resource[:backend]},cn=config\n"
     t << "changetype: add\n"
+    t << "objectClass: olcDatabaseConfig\n"
     t << "objectClass: olc#{resource[:backend].to_s.capitalize}Config\n"
     t << "olcDatabase: #{resource[:backend]}\n"
     t << "olcDbDirectory: #{resource[:directory]}\n" if resource[:directory]

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -20,10 +20,17 @@ Puppet::Type.newtype(:openldap_database) do
     defaultto do
       case Facter.value(:osfamily)
       when 'Debian'
-        if Facter.value(:operatingsystemmajrelease).to_i < 8
+        case Facter.value(:operatingsystem)
+        when 'Debian'
+          if Facter.value(:operatingsystemmajrelease).to_i < 8
+            'hdb'
+          else
+            'mdb'
+          end
+        when 'Ubuntu'
           'hdb'
         else
-          'mdb'
+          'hdb'
         end
       when 'RedHat'
         if Facter.value(:operatingsystemmajrelease).to_i < 7

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,10 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      $server_service_hasstatus = $::operatingsystemmajrelease ? {
-        '5'     => false,
-        default => true,
+      if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '5' {
+        $server_service_hasstatus = false
+      } else {
+        $server_service_hasstatus = true
       }
     }
     'RedHat': {

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,13 @@
       ]
     },
     {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,7 +10,7 @@ hosts.each do |host|
   # Install ruby-augeas
   case fact('osfamily')
   when 'Debian'
-    if fact('operatingsystemmajrelease').to_i < 7
+    if fact('operatingsystem') == 'Debian' and fact('operatingsystemmajrelease').to_i < 7
       on host, 'echo deb http://http.debian.net/debian-backports squeeze-backports main >> /etc/apt/sources.list'
       on host, 'apt-get update'
       on host, 'apt-get -y -t squeeze-backports install libaugeas0 augeas-lenses'


### PR DESCRIPTION
Closes #51

Some testing is required as we don't use the 15.04 pre-releases, so I am not sure that hdb is still the default backend.