### PR TITLE
Fixed regexp warning on ruby-1.8.7.

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -153,7 +153,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
       '-H',
       "ldap:///???(&(objectClass=olc#{resource[:backend].to_s.capitalize}Config)(olcSuffix=#{resource[:suffix]}))").split("\n").collect do |line|
       if line =~ /^olcDatabase: /
-        @property_hash[:index] = line.match(/^olcDatabase: {(\d+)}#{resource[:backend]}$/).captures[0]
+        @property_hash[:index] = line.match(/^olcDatabase: \{(\d+)\}#{resource[:backend]}$/).captures[0]
       end
     end
   end


### PR DESCRIPTION
Small patch to fix the following warnings on ruby-1.8.7:

/var/lib/puppet/lib/puppet/provider/openldap_database/olc.rb:157: warning: regexp has invalid interval
/var/lib/puppet/lib/puppet/provider/openldap_database/olc.rb:157: warning: regexp has `}' without escape