### PR TITLE
Revert "Use ruby to generate idempotent SSHA password (Fixes #35)" (#49)

### DIFF
--- a/lib/puppet/parser/functions/openldap_password.rb
+++ b/lib/puppet/parser/functions/openldap_password.rb
@@ -1,14 +1,16 @@
 module Puppet::Parser::Functions
   newfunction(:openldap_password, :type => :rvalue, :doc => <<-EOS
-    Returns the openldap password hash from the clear text password.
-  EOS
+      Returns the openldap password hash from the clear text password.
+    EOS
   ) do |args|
 
     raise(Puppet::ParseError, "openldap_password(): Wrong number of arguments given") if args.size < 1 or args.size > 2
 
-    password = args[0]
-    salt = Digest::SHA1.digest(lookupvar('::fqdn'))[0..4]
+    secret = args[0]
+    command = ['slappasswd', '-s', secret]
+    scheme = args[1] if args[1]
+    command << ['-h', scheme] if scheme
 
-    "{SSHA}" + Base64.encode64("#{Digest::SHA1.digest("#{password}#{salt}")}#{salt}").chomp
+    Puppet::Util::Execution.execute(command.flatten).strip
   end
 end

--- a/spec/unit/puppet/parser/functions/openldap_password_spec.rb
+++ b/spec/unit/puppet/parser/functions/openldap_password_spec.rb
@@ -3,36 +3,33 @@ require 'spec_helper'
 describe Puppet::Parser::Functions.function(:openldap_password) do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
-  on_supported_os.each do |os, facts|
-    context "on #{os}" do
-      before :each do
-        facts.each do |k, v|
-          scope.stubs(:lookupvar).with("::#{k}").returns(v)
-          scope.stubs(:lookupvar).with(k).returns(v)
-        end
-      end
+  it 'should exist' do
+    expect(Puppet::Parser::Functions.function('openldap_password')).to eq('function_openldap_password')
+  end
 
-      it 'should exist' do
-        expect(
-          Puppet::Parser::Functions.function('openldap_password')
-        ).to eq('function_openldap_password')
-      end
+  context 'when given a wrong number of arguments' do
+    it 'should fail' do
+      expect {
+        scope.function_openldap_password([])
+      }.to raise_error Puppet::ParseError, /Wrong number of arguments given/
+    end
+  end
 
-      context 'when given a wrong number of arguments' do
-        it 'should fail' do
-          expect {
-            scope.function_openldap_password([])
-          }.to raise_error Puppet::ParseError, /Wrong number of arguments given/
-        end
-      end
+  context 'when given only a secret' do
+    it 'should execute slappasswd on it' do
+      Puppet::Util::Execution.stubs(:execute).with([
+        'slappasswd', '-s', 'foo'
+      ]).returns("{SSHA}kKSBVuPOwlHp5HfcR3LBKyB7smTnbq9Y\n")
+      expect(scope.function_openldap_password(['foo'])).to eq('{SSHA}kKSBVuPOwlHp5HfcR3LBKyB7smTnbq9Y')
+    end
+  end
 
-      context 'when given only a secret' do
-        it 'should return the SSHA of the password with sha1("foo.example.com") as salt' do
-          expect(
-            scope.function_openldap_password(['secret'])
-          ).to eq('{SSHA}jZdUkbyDYvmpSKg0x/k879g+RY7EHbws5g==')
-        end
-      end
+  context 'when given a secret and a scheme' do
+    it 'should execute slappasswd on them' do
+      Puppet::Util::Execution.stubs(:execute).with([
+        'slappasswd', '-s', 'foo', '-h', '{MD5}'
+      ]).returns("{MD5}rL0Y20zC+Fzt72VPzMSk2A==\n")
+      expect(scope.function_openldap_password(['foo', '{MD5}'])).to eq('{MD5}rL0Y20zC+Fzt72VPzMSk2A==')
     end
   end
 end


### PR DESCRIPTION
This reverts commit 4b2f0b2741eda4345810c5705c1bfe65d5e0498e. Idempotent password hashing is done by the provider now, but the `openldap_password` function is still included for backwards compatibility. As such, it's prudent to ensure that it's secure, and the idempotent version of this function uses the same salt for all passwords generated for a particular agent.