### PR TITLE
Add ensure parameter to openldap::server::globalconf

### DIFF
--- a/manifests/server/globalconf.pp
+++ b/manifests/server/globalconf.pp
@@ -1,6 +1,7 @@
 # See README.md for details.
 define openldap::server::globalconf(
   $value,
+  $ensure = 'present',
 ) {
 
   if ! defined(Class['openldap::server']) {


### PR DESCRIPTION
Althought documentation shows an example with param ensure in openldap::server::globalconf and openldap_global_conf supports it, the parameter is not actually allowed, so I fix it.