### PR TITLE
Ensure parameter in opeldap::server::globalconf

### DIFF
--- a/manifests/server/globalconf.pp
+++ b/manifests/server/globalconf.pp
@@ -1,6 +1,7 @@
 # See README.md for details.
 define openldap::server::globalconf(
   $value,
+  $ensure = 'present',
 ) {
 
   if ! defined(Class['openldap::server']) {

--- a/manifests/server/globalconf.pp
+++ b/manifests/server/globalconf.pp
@@ -12,6 +12,7 @@ define openldap::server::globalconf(
     Openldap::Server::Globalconf[$title] ~> Class['openldap::server::service']
   }
   openldap_global_conf { $name:
+    ensure   => $ensure,
     provider => $::openldap::server::provider,
     target   => $::openldap::server::conffile,
     value    => $value,


### PR DESCRIPTION
Althought documentation shows an example with param ensure in openldap::server::globalconf and openldap_global_conf supports it, the parameter is not actually allowed. This is a fix