### PR TITLE
Add "initdb" parameter to openldap_database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/fixtures/
 .vagrant/
 .bundle/
 coverage/
+.*.swp

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -145,7 +145,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end
     t.delete
-    initdb
+    initdb if resource[:initdb] == :true
     @property_hash[:ensure] = :present
     slapcat(
       '-b',

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -94,4 +94,11 @@ Puppet::Type.newtype(:openldap_database) do
       return '[new password hash redacted]'
     end
   end
+
+  newparam(:initdb) do
+    desc "When true it initiales the database with the top object. When false, it does not create any object in the database, so you have to create it by other mechanism.  It defaults to true"
+
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
 end

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -6,6 +6,7 @@ define openldap::server::database(
   $backend   = undef,
   $rootdn    = undef,
   $rootpw    = undef,
+  $initdb    = undef,
 ) {
 
   if ! defined(Class['openldap::server']) {
@@ -44,6 +45,7 @@ define openldap::server::database(
     directory => $directory,
     rootdn    => $rootdn,
     rootpw    => $rootpw,
+    initdb    => $initdb,
   }
 
 }


### PR DESCRIPTION
so you could control if you want to create the initial top object and admin user when the database is created or leave it empty with no objects (e.g. it's usefull if you are including this openldap in a replication scenario)