### PR TITLE
Add support to configure replication attributes for a database

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -341,7 +341,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
       end
       t << "replace: olcMirrorMode\nolcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:mirrormode]
       t << "replace: olcSyncUseSubentry\nolcSyncUseSubentry: #{resource[:syncusesubentry]}\n-\n" if @property_flush[:syncusesubentry]
-      t << "delete: olcSyncrepl\n-\nreplace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
+      t << "replace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
       t.close
       Puppet.debug(IO.read t.path)
       begin

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -82,9 +82,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
         when /^olcSyncUseSubentry: /
           syncusesubentry = line.split(' ', 2)[1]
         when /^olcSyncrepl: /
-          if !syncrepl
-            syncrepl = Array.new
-          end
+          syncrepl ||= Array.new
           optvalue = line.split(' ',2)[1]
           syncrepl.push(optvalue.match(/^(\{\d+\})?(.+)$/).captures[1])
         end

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -76,7 +76,6 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
               dboptions[optname.match(/^olcDb(\S+)$/i).captures[0]] = optvalue
             end
           end
-        end
         when /^olcMirrorMode: /
           mirrormode = line.split(' ')[1] == 'TRUE' ? :true : :false
         when /^olcSyncUseSubentry: /

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -27,10 +27,12 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
       rootpw = nil
       readonly = nil
       sizelimit = nil
-      syncrepl = nil
       timelimit = nil
       updateref = nil
       dboptions = {}
+      mirrormode = nil
+      syncusesubentry = nil
+      syncrepl = nil
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
@@ -47,8 +49,6 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
           readonly = line.split(' ')[1]
         when /^olcSizeLimit: /i
           sizelimit = line.split(' ')[1]
-        when /^olcSyncrepl: /i
-          syncrepl = line.split(' ')[1]
         when /^olcTimeLimit: /i
           timelimit = line.split(' ')[1]
         when /^olcUpdateref: /i
@@ -77,23 +77,36 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
             end
           end
         end
+        when /^olcMirrorMode: /
+          mirrormode = line.split(' ')[1] == 'TRUE' ? :true : :false
+        when /^olcSyncUseSubentry: /
+          syncusesubentry = line.split(' ', 2)[1]
+        when /^olcSyncrepl: /
+          if !syncrepl
+            syncrepl = Array.new
+          end
+          optvalue = line.split(' ',2)[1]
+          syncrepl.push(optvalue.match(/^(\{\d+\})?(.+)$/).captures[1])
+        end
       end
       dbconfig = dbconfig.sort.collect { |x| x.split('}')[1] } if dbconfig
       new(
-        :ensure         => :present,
-        :name           => suffix,
-        :suffix         => suffix,
-        :index          => index.to_i,
-        :backend        => backend,
-        :directory      => directory,
-        :rootdn         => rootdn,
-        :rootpw         => rootpw,
-        :readonly       => readonly,
-        :sizelimit      => sizelimit,
-        :syncrepl       => syncrepl,
-        :timelimit      => timelimit,
-        :updateref      => updateref,
-        :dboptions      => dboptions
+        :ensure          => :present,
+        :name            => suffix,
+        :suffix          => suffix,
+        :index           => index.to_i,
+        :backend         => backend,
+        :directory       => directory,
+        :rootdn          => rootdn,
+        :rootpw          => rootpw,
+        :readonly        => readonly,
+        :sizelimit       => sizelimit,
+        :timelimit       => timelimit,
+        :updateref       => updateref,
+        :dboptions       => dboptions,
+        :mirrormode      => mirrormode,
+        :syncusesubentry => syncusesubentry,
+        :syncrepl        => syncrepl
       )
     end
   end
@@ -175,7 +188,6 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
     t << "olcDbIndex: objectClass eq\n" if !resource[:dboptions] or !resource[:dboptions]['index']
     t << "olcReadOnly: #{resource[:readonly]}\n" if resource[:readonly]
     t << "olcSizeLimit: #{resource[:sizelimit]}\n" if resource[:sizelimit]
-    t << "olcSyncrepl: #{resource[:syncrepl]}\n" if resource[:syncrepl]
     t << "olcTimeLimit: #{resource[:timelimit]}\n" if resource[:timelimit]
     t << "olcUpdateref: #{resource[:updateref]}\n" if resource[:updateref]
     if resource[:dboptions]
@@ -196,6 +208,9 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
         end
       end
     end
+    t << "olcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:mirrormode]
+    t << "olcSyncUseSubentry: #{resource[:syncusesubentry]}\n" if resource[:syncusesubentry]
+    t << resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n") + "\n" if resource[:syncrepl]
     t << "olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break\n"
     t << "olcAccess: to attrs=userPassword\n"
     t << "  by self write\n"
@@ -257,10 +272,6 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
     @property_flush[:sizelimit] = value
   end
 
-  def syncrepl=(value)
-    @property_flush[:syncrepl] = value
-  end
-
   def timelimit=(value)
     @property_flush[:timelimit] = value
   end
@@ -273,6 +284,18 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
     @property_flush[:dboptions] = value
   end
 
+  def mirrormode=(value)
+    @property_flush[:mirrormode] = value
+  end
+
+  def syncusesubentry=(value)
+    @property_flush[:syncusesubentry] = value
+  end
+
+  def syncrepl=(value)
+    @property_flush[:syncrepl] = value
+  end
+  
   def flush
     if not @property_flush.empty?
       t = Tempfile.new('openldap_database')
@@ -284,7 +307,6 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
       t << "replace: olcSuffix\nolcSuffix: #{resource[:suffix]}\n-\n" if @property_flush[:suffix]
       t << "replace: olcReadOnly\nolcReadOnly: #{resource[:readonly]}\n-\n" if @property_flush[:readonly]
       t << "replace: olcSizeLimit\nolcSizeLimit: #{resource[:sizelimit]}\n-\n" if @property_flush[:sizelimit]
-      t << "replace: olcSyncrepl\nolcSyncrepl: #{resource[:syncrepl]}\n-\n" if @property_flush[:syncrepl]
       t << "replace: olcTimeLimit\nolcTimeLimit: #{resource[:timelimit]}\n-\n" if @property_flush[:timelimit]
       t << "replace: olcUpdateref\nolcUpdateref: #{resource[:updateref]}\n-\n" if @property_flush[:updateref]
       if @property_flush[:dboptions]
@@ -319,6 +341,9 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
           end
         end
       end
+      t << "replace: olcMirrorMode\nolcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:mirrormode]
+      t << "replace: olcSyncUseSubentry\nolcSyncUseSubentry: #{resource[:syncusesubentry]}\n-\n" if @property_flush[:syncusesubentry]
+      t << "delete: olcSyncrepl\n-\nreplace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
       t.close
       Puppet.debug(IO.read t.path)
       begin

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -206,9 +206,9 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
         end
       end
     end
+    t << resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n") + "\n" if resource[:syncrepl]
     t << "olcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:mirrormode]
     t << "olcSyncUseSubentry: #{resource[:syncusesubentry]}\n" if resource[:syncusesubentry]
-    t << resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n") + "\n" if resource[:syncrepl]
     t << "olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break\n"
     t << "olcAccess: to attrs=userPassword\n"
     t << "  by self write\n"
@@ -339,9 +339,9 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
           end
         end
       end
+      t << "replace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
       t << "replace: olcMirrorMode\nolcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:mirrormode]
       t << "replace: olcSyncUseSubentry\nolcSyncUseSubentry: #{resource[:syncusesubentry]}\n-\n" if @property_flush[:syncusesubentry]
-      t << "replace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
       t.close
       Puppet.debug(IO.read t.path)
       begin

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
           optname.downcase!
           case optname
           when 'olcdbconfig'
-            dboptions['dbconfig'] = Array.new if !dboptions['dbconfig']
+            dboptions['dbconfig'] = [] if !dboptions['dbconfig']
             optvalue = optvalue.match(/^\{\d+\}(.+)$/).captures[0] if optvalue =~ /^\{\d+\}.+$/
             dboptions['dbconfig'].push(optvalue)
           when 'olcdbnosync'
@@ -81,7 +81,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
         when /^olcSyncUseSubentry: /
           syncusesubentry = line.split(' ', 2)[1]
         when /^olcSyncrepl: /
-          syncrepl ||= Array.new
+          syncrepl ||= []
           optvalue = line.split(' ',2)[1]
           syncrepl.push(optvalue.match(/^(\{\d+\})?(.+)$/).captures[1])
         end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -1,3 +1,5 @@
+require 'puppet/property/boolean'
+
 Puppet::Type.newtype(:openldap_database) do
   @doc = "Manages OpenLDAP BDB and HDB databases."
 
@@ -150,8 +152,12 @@ Puppet::Type.newtype(:openldap_database) do
     defaultto :minimum
   end
 
-  newproperty(:mirrormode) do
+  newproperty(:mirrormode, :boolean => true, :parent => Puppet::Property::Boolean) do
     desc "This option puts a replica database into \"mirror\" mode"
+
+    munge do |value|
+        super(value) ? :true : :false
+    end
   end
 
   newproperty(:syncusesubentry) do

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -117,10 +117,6 @@ Puppet::Type.newtype(:openldap_database) do
     desc "Specifies the maximum number of entries to return from a search operation."
   end
 
-  newproperty(:syncrepl) do
-    desc "This directive specifies the current database as a replica of the master content."
-  end
-
   newproperty(:timelimit) do
     desc "Specifies the maximum number of seconds (in real time) slapd will spend answering a search request."
   end
@@ -152,5 +148,19 @@ Puppet::Type.newtype(:openldap_database) do
 
     newvalues(:inclusive, :minimum)
     defaultto :minimum
+  end
+
+  newproperty(:mirrormode) do
+    desc "This  option  puts  a  replica database into \"mirror\" mode"
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:syncusesubentry) do
+    desc "Store  the  syncrepl  contextCSN  in  a  subentry  instead of the context entry of the database"
+  end
+
+  newproperty(:syncrepl, :array_matching => :all) do
+    desc "Specify  the  current  database  as a replica which is kept up-to-date with the master content by establishing the current slapd(8) as a replication consumer site running  a syncrepl  replication  engine."
   end
 end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -104,7 +104,7 @@ Puppet::Type.newtype(:openldap_database) do
     end
   end
 
-  newparam(:initdb) do
+  newparam(:initdb, :boolean => true) do
     desc "When true it initiales the database with the top object. When false, it does not create any object in the database, so you have to create it by other mechanism. It defaults to true"
 
     newvalues(:true, :false)

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -103,7 +103,7 @@ Puppet::Type.newtype(:openldap_database) do
   end
 
   newparam(:initdb) do
-    desc "When true it initiales the database with the top object. When false, it does not create any object in the database, so you have to create it by other mechanism.  It defaults to true"
+    desc "When true it initiales the database with the top object. When false, it does not create any object in the database, so you have to create it by other mechanism. It defaults to true"
 
     newvalues(:true, :false)
     defaultto(:true)
@@ -151,16 +151,14 @@ Puppet::Type.newtype(:openldap_database) do
   end
 
   newproperty(:mirrormode) do
-    desc "This  option  puts  a  replica database into \"mirror\" mode"
-
-    newvalues(:true, :false)
+    desc "This option puts a replica database into \"mirror\" mode"
   end
 
   newproperty(:syncusesubentry) do
-    desc "Store  the  syncrepl  contextCSN  in  a  subentry  instead of the context entry of the database"
+    desc "Store the syncrepl contextCSN in a subentry instead of the context entry of the database"
   end
 
   newproperty(:syncrepl, :array_matching => :all) do
-    desc "Specify  the  current  database  as a replica which is kept up-to-date with the master content by establishing the current slapd(8) as a replication consumer site running  a syncrepl  replication  engine."
+    desc "Specify the current database as a replica which is kept up-to-date with the master content by establishing the current slapd(8) as a replication consumer site running a syncrepl replication engine."
   end
 end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -152,12 +152,10 @@ Puppet::Type.newtype(:openldap_database) do
     defaultto :minimum
   end
 
-  newproperty(:mirrormode, :boolean => true, :parent => Puppet::Property::Boolean) do
+  newproperty(:mirrormode, :boolean => true) do
     desc "This option puts a replica database into \"mirror\" mode"
+    newvalues(:true, :false)
 
-    munge do |value|
-        super(value) ? :true : :false
-    end
   end
 
   newproperty(:syncusesubentry) do

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -1,20 +1,23 @@
 # See README.md for details.
 define openldap::server::database(
-  $ensure    = present,
-  $directory = '/var/lib/ldap',
-  $suffix    = $title,
-  $backend   = undef,
-  $rootdn    = undef,
-  $rootpw    = undef,
-  $initdb    = undef,
-  $readonly  = false,
-  $sizelimit = undef,
-  $syncrepl  = undef,
-  $timelimit = undef,
-  $updateref = undef,
+  $ensure          = present,
+  $directory       = '/var/lib/ldap',
+  $suffix          = $title,
+  $backend         = undef,
+  $rootdn          = undef,
+  $rootpw          = undef,
+  $initdb          = undef,
+  $readonly        = false,
+  $sizelimit       = undef,
+  $timelimit       = undef,
+  $updateref       = undef,
   # BDB/HDB options
-  $dboptions = undef,
-  $synctype  = undef,
+  $dboptions       = undef,
+  $synctype        = undef,
+  # Synchronization options
+  $mirrormode      = undef,
+  $syncusesubentry = undef,
+  $syncrepl        = undef,
 ) {
 
   if ! defined(Class['openldap::server']) {
@@ -45,22 +48,24 @@ define openldap::server::database(
   }
 
   openldap_database { $title:
-    ensure    => $ensure,
-    suffix    => $suffix,
-    provider  => $::openldap::server::provider,
-    target    => $::openldap::server::conffile,
-    backend   => $backend,
-    directory => $directory,
-    rootdn    => $rootdn,
-    rootpw    => $rootpw,
-    initdb    => $initdb,
-    readonly  => $readonly,
-    sizelimit => $sizelimit,
-    syncrepl  => $syncrepl,
-    timelimit => $timelimit,
-    updateref => $updateref,
-    dboptions => $dboptions,
-    synctype  => $synctype,
+    ensure          => $ensure,
+    suffix          => $suffix,
+    provider        => $::openldap::server::provider,
+    target          => $::openldap::server::conffile,
+    backend         => $backend,
+    directory       => $directory,
+    rootdn          => $rootdn,
+    rootpw          => $rootpw,
+    initdb          => $initdb,
+    readonly        => $readonly,
+    sizelimit       => $sizelimit,
+    timelimit       => $timelimit,
+    updateref       => $updateref,
+    dboptions       => $dboptions,
+    synctype        => $synctype,
+    mirrormode      => $mirrormode,
+    syncusesubentry => $syncusesubentry,
+    syncrepl        => $syncrepl,
   }
 
 }


### PR DESCRIPTION
This PR add properties _mirrormode_, _syncusesubentry_ and _syncrepl_ to ```openldap_database``` (and ```openldap::server::database```) so you could define replication attributes for a database.