### PR TITLE
add converttoldif parameter on schema class

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,16 +153,18 @@ openldap::server::access {
 
 ###Configuring Schemas
 ```
-openldap::server::overlay { "core"
-	ensure => present,
+openldap::server::schema { 'samba':
+  ensure => present,
+  path => '/etc/ldap/schema/samba.schema',
+  require => Openldap::Server::Schema["inetorgperson"],
 }
 
-openldap::server::schema { "samba":
-	ensure => present,
-	path => "/etc/ldap/schema/samba.schema",
-	require => Openldap::Server::Schema["inetorgperson"], before => Openldap::Server::Schema["core-fd"
+openldap::server::schema { 'nis':
+  ensure       => present,
+  path         => '/etc/ldap/schema/nis.ldif',
+  convertoldif => false,
+  require      => Openldap::Server::Schema["inetorgperson"],
 }
-
 
 Reference
 ---------

--- a/lib/puppet/provider/openldap_schema/olc.rb
+++ b/lib/puppet/provider/openldap_schema/olc.rb
@@ -68,9 +68,13 @@ Puppet::Type.type(:openldap_schema).provide(:olc) do
 
     begin
       schema = IO.read resource[:path]
-      t << self.class.schemaToLdif(schema, resource[:name])
-      t.close
+      if resource[:converttoldif]
+        t << self.class.schemaToLdif(schema, resource[:name])
+      else
+        t << schema
+      end
 
+      t.close
       ldapadd('-cQY', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
@@ -80,7 +84,7 @@ Puppet::Type.type(:openldap_schema).provide(:olc) do
 
   def exists?
     @property_hash[:ensure] == :present
-    end
+  end
 
   def destroy
     raise Puppet::Error, "Removing schemas is not supported by this provider. Slapd needs to be stopped and the schema must be removed manually."

--- a/lib/puppet/type/openldap_schema.rb
+++ b/lib/puppet/type/openldap_schema.rb
@@ -11,4 +11,9 @@ Puppet::Type.newtype(:openldap_schema) do
     desc "The location to the schema file."
   end
 
+  newparam(:converttoldif, :boolean => true) do
+    desc "Convert legacy schema file to ldif format"
+    defaultto :true
+  end
+
 end

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -8,9 +8,12 @@ define openldap::server::schema(
   }
 ) {
 
+
   if ! defined(Class['openldap::server']) {
     fail 'class ::openldap::server has not been evaluated'
   }
+
+  validate_bool($converttoldif)
 
   if $::openldap::server::provider == 'augeas' {
     Class['openldap::server::install'] ->
@@ -23,8 +26,9 @@ define openldap::server::schema(
   }
 
   openldap_schema { $title:
-    ensure   => $ensure,
-    path     => $path,
-    provider => $::openldap::server::provider,
+    ensure        => $ensure,
+    path          => $path,
+    provider      => $::openldap::server::provider,
+    converttoldif => $converttoldif,
   }
 }

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -1,7 +1,8 @@
 # See README.md for details.
 define openldap::server::schema(
-  $ensure = undef,
-  $path = $::osfamily ? {
+  $ensure        = undef,
+  $converttoldif = true,
+  $path          = $::osfamily ? {
     'Debian' => "/etc/ldap/schema/${title}.schema",
     'Redhat' => "/etc/openldap/schema/${title}.schema",
   }


### PR DESCRIPTION
I would like the ability to specify schema files that are already in ldif format. This pull request adds a parameter 'converttoldif' (boolean) to allow this functionality.