### PR TITLE
Add olcSyncProvConfig to overlay config entry when configuring syncprov overlay

### DIFF
--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -87,6 +87,8 @@ Puppet::Type.type(:openldap_overlay).provide(:olc) do
       t << "objectClass: olcPcacheConfig\n"
     when 'accesslog'
       t << "objectClass: olcAccessLogConfig\n"
+    when 'syncprov'
+      t << "objectClass: olcSyncProvConfig\n"
     end
     t << "olcOverlay: #{resource[:overlay]}\n"
     if resource[:options]


### PR DESCRIPTION
In order to be able to add options to the overlay