### PR TITLE
slapdconf: allow to configure TLS using a MozNSS database on rhel=>6

### DIFF
--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -33,7 +33,7 @@ class openldap::server::slapdconf {
         validate_string($::openldap::server::ssl_cert)
         openldap::server::globalconf { 'TLSCertificate':
           value => {
-            'TLSCertificateFile'    => $::openldap::server::ssl_cert,
+            'TLSCertificateFile' => $::openldap::server::ssl_cert,
           },
         }
         if $::openldap::server::ssl_key {

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -44,11 +44,12 @@ class openldap::server::slapdconf {
       if $::openldap::server::ssl_key {
         validate_absolute_path($::openldap::server::ssl_cert)
         validate_absolute_path($::openldap::server::ssl_key)
-        openldap::server::globalconf { 'TLSCertificateFile':
-          value => $::openldap::server::ssl_cert,
-        }
-        openldap::server::globalconf { 'TLSCertificateKeyFile':
-          value => $::openldap::server::ssl_key,
+
+        openldap::server::globalconf { 'TLSCertificate':
+          value => {
+            'TLSCertificateFile'    => $::openldap::server::ssl_cert,
+            'TLSCertificateKeyFile' => $::openldap::server::ssl_key,
+          },
         }
       } else {
         fail 'You must specify a ssl_key'

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -29,7 +29,7 @@ class openldap::server::slapdconf {
   }
 
   if $::openldap::server::ssl_cert {
-    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease >= 6 {
+    if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '6') > -1 {
         validate_string($::openldap::server::ssl_cert)
         openldap::server::globalconf { 'TLSCertificate':
           value => {

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -29,23 +29,40 @@ class openldap::server::slapdconf {
   }
 
   if $::openldap::server::ssl_cert {
-    if $::openldap::server::ssl_key {
-      validate_absolute_path($::openldap::server::ssl_cert)
-      validate_absolute_path($::openldap::server::ssl_key)
-      openldap::server::globalconf { 'TLSCertificate':
-        value => {
-          'TLSCertificateFile'    => $::openldap::server::ssl_cert,
-          'TLSCertificateKeyFile' => $::openldap::server::ssl_key,
-        },
-      }
-      if $::openldap::server::ssl_ca {
-        validate_absolute_path($::openldap::server::ssl_ca)
-        openldap::server::globalconf { 'TLSCACertificateFile':
-          value => $::openldap::server::ssl_ca,
+    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease >= 6 {
+        validate_string($::openldap::server::ssl_cert)
+        openldap::server::globalconf { 'TLSCertificate':
+          value => {
+            'TLSCertificateFile'    => $::openldap::server::ssl_cert,
+          },
         }
-      }
+        if $::openldap::server::ssl_key {
+          validate_string($::openldap::server::ssl_key)
+          openldap::server::globalconf { 'TLSCertificateKeyFile':
+            value => {
+              'TLSCertificateKeyFile' => $::openldap::server::ssl_key,
+            },
+          }
+        }
     } else {
-      fail 'You must specify a ssl_key'
+      if $::openldap::server::ssl_key {
+        validate_absolute_path($::openldap::server::ssl_cert)
+        validate_absolute_path($::openldap::server::ssl_key)
+        openldap::server::globalconf { 'TLSCertificate':
+          value => {
+            'TLSCertificateFile'    => $::openldap::server::ssl_cert,
+            'TLSCertificateKeyFile' => $::openldap::server::ssl_key,
+          },
+        }
+      } else {
+        fail 'You must specify a ssl_key'
+      }
+    }
+    if $::openldap::server::ssl_ca {
+      validate_absolute_path($::openldap::server::ssl_ca)
+      openldap::server::globalconf { 'TLSCACertificateFile':
+        value => $::openldap::server::ssl_ca,
+      }
     }
   } elsif $::openldap::server::ssl_key {
     fail 'You must specify a ssl_cert'

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -31,28 +31,24 @@ class openldap::server::slapdconf {
   if $::openldap::server::ssl_cert {
     if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '6') > -1 {
         validate_string($::openldap::server::ssl_cert)
-        openldap::server::globalconf { 'TLSCertificate':
-          value => {
-            'TLSCertificateFile' => $::openldap::server::ssl_cert,
-          },
+        openldap::server::globalconf { 'TLSCertificateFile':
+          value => $::openldap::server::ssl_cert,
         }
         if $::openldap::server::ssl_key {
           validate_string($::openldap::server::ssl_key)
           openldap::server::globalconf { 'TLSCertificateKeyFile':
-            value => {
-              'TLSCertificateKeyFile' => $::openldap::server::ssl_key,
-            },
+            value => $::openldap::server::ssl_key,
           }
         }
     } else {
       if $::openldap::server::ssl_key {
         validate_absolute_path($::openldap::server::ssl_cert)
         validate_absolute_path($::openldap::server::ssl_key)
-        openldap::server::globalconf { 'TLSCertificate':
-          value => {
-            'TLSCertificateFile'    => $::openldap::server::ssl_cert,
-            'TLSCertificateKeyFile' => $::openldap::server::ssl_key,
-          },
+        openldap::server::globalconf { 'TLSCertificateFile':
+          value => $::openldap::server::ssl_cert,
+        }
+        openldap::server::globalconf { 'TLSCertificateKeyFile':
+          value => $::openldap::server::ssl_key,
         }
       } else {
         fail 'You must specify a ssl_key'

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -29,7 +29,7 @@ class openldap::server::slapdconf {
   }
 
   if $::openldap::server::ssl_cert {
-    if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '6') > -1 {
+    if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '6') >= 0 {
         validate_string($::openldap::server::ssl_cert)
         openldap::server::globalconf { 'TLSCertificateFile':
           value => $::openldap::server::ssl_cert,

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -32,9 +32,9 @@ describe 'openldap::server::slapdconf' do
         when 'RedHat'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateFile') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCACertificateFile') }
-          it { is_expected.not_to contain_openldap__globalconf( 'TLSCertificateKeyFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
+          it { is_expected.not_to contain_openldap__server___globalconf( 'TLSCertificateKeyFile') }
         end
       end
 
@@ -46,15 +46,15 @@ describe 'openldap::server::slapdconf' do
         when 'Debian'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateFile') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCACertificateFile') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateKeyFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateKeyFile') }
         when 'RedHat'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateFile') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCACertificateFile') }
-          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateKeyFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateKeyFile') }
         end
       end
     end

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -27,12 +27,11 @@ describe 'openldap::server::slapdconf' do
         end
         case facts[:osfamily]
         when 'Debian'
-          it { is_expected.to contain_class('openldap::server::slapdconf') }
           it { expect { is_expected.to compile }.to raise_error(/You must specify a ssl_key/) }
         when 'RedHat'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificate') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
           it { is_expected.not_to contain_openldap__server___globalconf( 'TLSCertificateKeyFile') }
         end
@@ -46,13 +45,13 @@ describe 'openldap::server::slapdconf' do
         when 'Debian'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificate') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateKeyFile') }
         when 'RedHat'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificate') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateKeyFile') }
         end

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -32,7 +32,7 @@ describe 'openldap::server::slapdconf' do
         when 'RedHat'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificate') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
           it { is_expected.not_to contain_openldap__server___globalconf( 'TLSCertificateKeyFile') }
         end
@@ -46,13 +46,13 @@ describe 'openldap::server::slapdconf' do
         when 'Debian'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificate') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateKeyFile') }
         when 'RedHat'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('openldap::server::slapdconf') }
-          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificate') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCACertificateFile') }
           it { is_expected.to contain_openldap__server__globalconf( 'TLSCertificateKeyFile') }
         end

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -16,6 +16,47 @@ describe 'openldap::server::slapdconf' do
         it { is_expected.to contain_class('openldap::server::slapdconf') }
         it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with({:ensure => :absent,})}
       end
+
+      # On rhel, openldap is linked against moz nss:
+      # ssl_ca parameter should contain the path to the moz nss database
+      # ssl_cert parameter should contain the name of the certificate stored into the moz nss database
+      # ssl_key can be omitted/is not used
+      context 'with ssl_cert and ssl_ca set but not ssl_key' do
+        let :pre_condition do
+          "class {'openldap::server': ssl_cert => 'my-domain.com', ssl_ca => '/etc/openldap/certs'}"
+        end
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_class('openldap::server::slapdconf') }
+          it { expect { is_expected.to compile }.to raise_error(/You must specify a ssl_key/) }
+        when 'RedHat'
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('openldap::server::slapdconf') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCACertificateFile') }
+          it { is_expected.not_to contain_openldap__globalconf( 'TLSCertificateKeyFile') }
+        end
+      end
+
+      context 'with ssl_cert, ssl_key and ssl_ca set' do
+        let :pre_condition do
+          "class {'openldap::server': ssl_cert => '/etc/openldap/certs/fqdn.tld.crt', ssl_key => '/etc/openldap/certs/fqdn.tld.key', ssl_ca => '/etc/openldap/certs/ca.crt'}"
+        end
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('openldap::server::slapdconf') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCACertificateFile') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateKeyFile') }
+        when 'RedHat'
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('openldap::server::slapdconf') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateFile') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCACertificateFile') }
+          it { is_expected.to contain_openldap__globalconf( 'TLSCertificateKeyFile') }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Pull Request for addressing #88.
When using OpenLDAP build against moznss (rhel >= 6), olcTLSCertificateFile should be a string not a path.
olcTLSCertificateKeyFile is optional.
olcTLSCACertificateFile might also probably be set as required.
