### PR TITLE
add cn=config suffix to database

### DIFF
--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -112,14 +112,18 @@ Puppet::Type.type(:openldap_overlay).provide(:olc) do
   end
 
   def getDn(suffix)
-    slapcat(
-      '-b',
-      'cn=config',
-      '-H',
-      "ldap:///???(olcSuffix=#{suffix})"
-    ).split("\n").collect do |line|
-      if line =~ /^dn: /
-        return line.split(' ')[1]
+    if suffix == 'cn=config'
+      return 'olcDatabase={0}config,cn=config'
+    else
+      slapcat(
+        '-b',
+        'cn=config',
+        '-H',
+        "ldap:///???(olcSuffix=#{suffix})"
+      ).split("\n").collect do |line|
+        if line =~ /^dn: /
+          return line.split(' ')[1]
+        end
       end
     end
   end
@@ -135,7 +139,9 @@ Puppet::Type.type(:openldap_overlay).provide(:olc) do
       if line =~ /^dn: olcDatabase=#{database.gsub('{', '\{').gsub('}','\}')},/
         found = true
       end
-      if line =~ /^olcSuffix: / and found
+      if database == '{0}config'
+        return 'cn=config'
+      elsif line =~ /^olcSuffix: / and found
         return line.split(' ')[1]
       end
     end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -18,7 +18,7 @@ Puppet::Type.newtype(:openldap_database) do
 
   newproperty(:backend) do
     desc "The name of the backend."
-    newvalues('bdb', 'hdb', 'mdb', 'monitor')
+    newvalues('bdb', 'hdb', 'mdb', 'monitor', 'config')
     defaultto do
       case Facter.value(:osfamily)
       when 'Debian'
@@ -47,7 +47,7 @@ Puppet::Type.newtype(:openldap_database) do
   newproperty(:directory) do
     desc "The directory where the BDB files containing this database and associated indexes live."
     defaultto do
-      if "#{@resource[:backend]}" != "monitor"
+      if "#{@resource[:backend]}" != "monitor" and "#{@resource[:backend]}" != "config"
         '/var/lib/ldap'
       end
     end
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:openldap_database) do
 
     newvalues(:true, :false)
     defaultto do
-      if "#{@resource[:backend]}" == "monitor"
+      if "#{@resource[:backend]}" == "monitor" or "#{@resource[:backend]}" == "config"
         :false
       else
         :true

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -27,6 +27,7 @@ define openldap::server::database(
 
   $manage_directory = $backend ? {
     'monitor' => undef,
+    'config'  => undef,
     default   => $directory ? {
       undef   => '/var/lib/ldap',
       default => $directory,
@@ -46,7 +47,7 @@ define openldap::server::database(
     Openldap::Server::Database['dc=my-domain,dc=com'] -> Openldap::Server::Database[$title]
   }
 
-  if $ensure == present and $backend != 'monitor' {
+  if $ensure == present and $backend != 'monitor' and $backend != 'config' {
     validate_absolute_path($manage_directory)
     file { $manage_directory:
       ensure => directory,

--- a/spec/unit/puppet/type/openldap_database_spec.rb
+++ b/spec/unit/puppet/type/openldap_database_spec.rb
@@ -19,6 +19,7 @@ describe Puppet::Type.type(:openldap_database) do
     end
     it "should allow valid suffix" do
       expect { described_class.new(:name => 'dc=example,dc=com') }.to_not raise_error
+      expect { described_class.new(:name => 'cn=config') }.to_not raise_error
     end
   end
 
@@ -56,6 +57,9 @@ describe Puppet::Type.type(:openldap_database) do
       end
       it "should support hdb as a value for backend" do
         expect { described_class.new(:name => 'foo', :backend => 'hdb') }.to_not raise_error
+      end
+      it "should support config as a value for backend" do
+        expect { described_class.new(:name => 'foo', :backend => 'config') }.to_not raise_error
       end
       it "should not support other values" do
         expect { described_class.new(:name => 'foo', :backend => 'bar') }.to raise_error(Puppet::Error, /Invalid value/)


### PR DESCRIPTION

Now, we can use `puppet resource openldap_database`

and define a database for cn=config

```
openldap::server::database { 'cn=config' :
  backend    => 'config',
}
```