### PR TITLE
Refactor openldap::server::access

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,26 +128,155 @@ openldap::server::overlay { 'memberof on dc=example,dc=com':
 ###Configuring ACPs/ACLs
 
 ```puppet
-openldap::server::access {
-  'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com':
-    access => 'write';
-  'to attrs=userPassword,shadowLastChange by anonymous on dc=example,dc=com':
-    access => 'auth';
-  'to attrs=userPassword,shadowLastChange by self on dc=example,dc=com':
-    access => 'write';
-  'to attrs=userPassword,shadowLastChange by * on dc=example,dc=com':
-    access => 'none';
+openldap::server::access { '0 on dc=example,dc=com':
+  what   => 'attrs=userPassword,shadowLastChange',
+  access => [
+    'by dn="cn=admin,dc=example,dc=com" write',
+    'by anonymous auth',
+    'by self write',
+    'by * none',
+  ],
+} ->
+
+openldap::server::access { '1 on dc=example,dc=com' :
+  what   => 'dn.base=""'
+  access => [
+    'by * read'
+  ],
+} ->
+
+openldap::server::access { '2 on dc=example,dc=com' :
+  islast => true,
+  what   => '*'
+  access => [
+    'by dn="cn=admin,dc=example,dc=com" write',
+    'by * read',
+  ],
 }
 
-openldap::server::access { 'to dn.base="" by * on dc=example,dc=com':
-  access => 'read',
+```
+
+from the openldap [documentation](http://www.openldap.org/doc/admin24/slapdconf2.html)
+> The frontend is a special database that is used to hold database-level 
+options that should be applied to all the other databases. Subsequent database
+definitions may also override some frontend settings.
+
+So use the suffix 'frontend' for this special database
+
+
+```puppet
+openldap::server::access { '0 on frontend' :
+  what   => '*',
+  access => [
+    'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+    'by * break',
+  ],
+}
+```
+
+
+####Note #1:
+The chaining arrows `->` are importants if you want to order your entries.
+Openldap put the entry as the last available position.
+So if you got in your ldap:
+```
+ olcAccess: {0}to ...
+ olcAccess: {1}to ...
+ olcAccess: {2}to ...
+```
+
+  Even if you set the parameter `position => '4'`, the next entry will be set as
+
+```
+ olcAccess: {3}to ...
+```
+
+####Note #2:
+  The parameter `islast` is used for purging remaining entries
+  So if you got in your ldap:
+```
+ olcAccess: {0}to ...
+ olcAccess: {1}to ...
+ olcAccess: {2}to ...
+ olcAccess: {3}to ...
+```
+
+And set `islast => true` in `position => 1`, entries 2 and 3 will get deleted.
+
+####Call your acl from a hash:
+
+```puppet
+$acl_hash = {
+  'acl 1' => {
+    suffix   => 'dc=example,dc=com',
+    position => '1',
+    what     => 'attrs=userPassword,shadowLastChange',
+    by       => 'dn="cn=admin,dc=example,dc=com"',
+    access   => 'write',
+  },
+  'acl 2' => {
+    suffix   => 'dc=example,dc=com',
+    position => '2',
+    what     => 'attrs=userPassword,shadowLastChange',
+    by       => 'anonymous',
+    access   => 'auth',
+  },
+  'acl 3' => {
+    suffix   => 'dc=example,dc=com',
+    position => '3',
+    what     => 'attrs=userPassword,shadowLastChange',
+    by       => 'self',
+    access   => 'write',
+  },
 }
 
-openldap::server::access {
-  'to * by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com':
-    access => 'write';
-  'to * by * on dc=example,dc=com':
-    access => 'read';
+$acl_hash_keys = keys($acl_hash)
+openldap::server::access_wrapper { $acl_hash_keys :
+  hash => $acl_hash,
+}
+```
+
+And with a little help of an inline\_template, you can auto-generate your list
+of acl like so:
+
+```puppet
+$acl = {
+  '1 to *' => [
+    'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+    'by dn.exact=cn=admin,dc=example,dc=com write',
+    'by dn.exact=cn=replicator,dc=example,dc=com read',
+    'by * break',
+  ],
+  'to attrs=userPassword,shadowLastChange' => [
+    'by dn="cn=admin,dc=example,dc=com" write',
+    'by self write',
+    'by anonymous auth',
+  ],
+  '2 to *' => [
+    'by self read',
+  ],
+}
+
+$acl_hash_yaml = inline_template('<%=
+  position = -1
+  acl.map { |to,access|
+    position = position + 1
+    {
+      "#{position} on dc=example,dc=com" => {
+        "position" => position,
+        "what"     => to[/.*to (.*),1],
+        "access"   => access,
+        "suffix"   => "dc=example,dc=com",
+      }
+    }
+}.flatten.reduce({}, :update).to_yaml
+%>')
+
+$acl_hash = parseyaml($acl_hash_yaml)
+$acl_hash_keys = keys($acl_hash)
+
+openldap::server::access_wrapper { $acl_hash_keys :
+  hash => $acl_hash,
 }
 ```
 

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -160,6 +160,7 @@ Puppet::Type.
       ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
+    end
   end
 
   def islast=(value)

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -232,7 +232,7 @@ Puppet::Type.
       t.close
       Puppet.debug(IO.read t.path)
       begin
-        ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+        ldapmodify(t.path)
       rescue Exception => e
         raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
       end

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -168,24 +168,7 @@ Puppet::Type.
   end
 
   def access=(value)
-    t = Tempfile.new('openldap_access')
-    t << "dn: #{getDn(@property_hash[:suffix])}\n"
-    t << "changetype: modify\n"
-    t << "delete: olcAccess\n"
-    t << "olcAccess: {#{@property_hash[:position]}}\n"
-    t << "-\n"
-    t << "add: olcAccess\n"
-    t << "olcAccess: {#{@property_hash[:position]}}to #{resource[:what]}\n"
-    resource[:access].each do |a|
-      t << "  #{a}\n"
-    end
-    t.close
-    Puppet.debug(IO.read t.path)
-    begin
-      ldapmodify(t.path)
-    rescue Exception => e
-      raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
-    end
+    @property_flush[:access] = value
   end
 
   def islast=(value)

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -25,19 +25,18 @@ Puppet::Type.
           suffix = line.split(' ')[1]
         when /^olcAccess: /
           position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?)(\s+by\s+.*)+$/).captures
-          bys.split(' by ')[1..-1].each { |b|
-            by, access, control = b.strip.match(/^(\S+\"[^\"]+\"|\S+)\s+(\S+)(\s+\S+)?$/).captures
-            i << new(
-              :name     => "to #{what} by #{by} on #{suffix}",
-              :ensure   => :present,
-              :position => position,
-              :what     => what,
-              :by       => by,
-              :suffix   => suffix,
-              :access   => access,
-              :control  => control
-            )
+          access = []
+          bys.split(/(?= by .+)/).each { |b|
+            access << b.lstrip
           }
+          i << new(
+            :name     => "#{position} on #{suffix}",
+            :ensure   => :present,
+            :position => position,
+            :what     => what,
+            :access   => access,
+            :suffix   => suffix,
+          )
         end
       end
     end
@@ -49,16 +48,15 @@ Puppet::Type.
     accesses = instances
     resources.keys.each do |name|
       if provider = accesses.find{ |access|
-        access.what == resources[name][:what] &&
-          access.by == resources[name][:by] &&
-          access.suffix == resources[name][:suffix]
+        access.suffix == resources[name][:suffix] &&
+        access.position == resources[name][:position]
       }
         resources[name].provider = provider
       end
     end
   end
 
-  def getDn(suffix)
+  def self.getDn(suffix)
     if suffix == 'cn=frontend'
       return 'olcDatabase={-1}frontend,cn=config'
     elsif suffix == 'cn=config'
@@ -85,9 +83,16 @@ Puppet::Type.
   def create
     position = "{#{resource[:position]}}" if resource[:position]
     t = Tempfile.new('openldap_access')
-    t << "dn: #{getDn(resource[:suffix])}\n"
+    t << "dn: #{self.class.getDn(resource[:suffix])}\n"
     t << "add: olcAccess\n"
-    t << "olcAccess: #{position}to #{resource[:what]} by #{resource[:by]} #{resource[:access]}\n"
+    if resource[:position]
+      t << "olcAccess: {#{resource[:position]}}to #{resource[:what]}\n"
+    else
+      t << "olcAccess: to #{resource[:what]}\n"
+    end
+    resource[:access].each do |a|
+      t << "  #{a}\n"
+    end
     t.close
     Puppet.debug(IO.read t.path)
     begin
@@ -99,13 +104,30 @@ Puppet::Type.
 
   def destroy
     t = Tempfile.new('openldap_access')
-    t << "dn: #{getDn(@property_hash[:suffix])}\n"
+    t << "dn: #{self.class.getDn(@property_hash[:suffix])}\n"
     t << "changetype: modify\n"
     t << "delete: olcAccess\n"
     t << "olcAccess: {#{@property_hash[:position]}}\n"
     t.close
     Puppet.debug(IO.read t.path)
     slapdd('-b', 'cn=config', '-l', t.path)
+  end
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def what=(value)
+    @property_flush[:what] = value
+  end
+
+  def suffix=(value)
+    @property_flush[:suffix] = value
+  end
+
+  def position=(value)
+    @property_flush[:position] = value
   end
 
   def access=(value)
@@ -123,7 +145,60 @@ Puppet::Type.
       ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
-    end
   end
+
+  def getCurrentOlcAccess(suffix)
+    i = []
+    slapcat(
+      '-H',
+      "ldap:///#{self.class.getDn(suffix)}???(olcAccess=*)"
+    ).split("\n\n").collect do |paragraph|
+      paragraph.gsub("\n ", '').split("\n").collect do |line|
+        case line
+        when /^olcAccess: /
+          position, content = line.match(/^olcAccess:\s+\{(\d+)\}(.*)$/).captures
+          i << {
+            :position => position,
+            :content => content,
+          }
+        end
+      end
+    end
+    return i
+  end
+
+  def flush
+    if not @property_flush.empty?
+      current_olcAccess = getCurrentOlcAccess(resource[:suffix])
+      t = Tempfile.new('openldap_access')
+      t << "dn: #{self.class.getDn(resource[:suffix])}\n"
+      t << "changetype: modify\n"
+      t << "replace: olcAccess\n"
+      if resource[:position]
+        position = resource[:position]
+      else
+        position = @property_hash[:position]
+      end
+      current_olcAccess.each do |olcAccess|
+        if olcAccess[:position].to_i == position.to_i
+          t << "olcAccess: {#{position}}to #{resource[:what]}\n"
+          resource[:access].each do |a|
+            t << "  #{a}\n"
+          end
+        else
+          t << "olcAccess: {#{olcAccess[:position]}}#{olcAccess[:content]}\n"
+        end
+      end
+      t.close
+      Puppet.debug(IO.read t.path)
+      begin
+        ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      rescue Exception => e
+        raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
+      end
+    end
+    @property_hash = resource.to_hash
+  end
+
 
 end

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -155,7 +155,10 @@ Puppet::Type.
     t << "olcAccess: {#{@property_hash[:position]}}\n"
     t << "-\n"
     t << "add: olcAccess\n"
-    t << "olcAccess: {#{@property_hash[:position]}}to #{resource[:what]} by #{resource[:by]} #{resource[:access]}\n"
+    t << "olcAccess: {#{@property_hash[:position]}}to #{resource[:what]}\n"
+    resource[:access].each do |a|
+      t << "  #{a}\n"
+    end
     t.close
     Puppet.debug(IO.read t.path)
     begin

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -41,7 +41,7 @@ Puppet::Type.
             :what     => what,
             :access   => access,
             :suffix   => suffix,
-            :islast   => islast,
+            :islast   => islast
           )
         end
       end

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -66,6 +66,20 @@ Puppet::Type.
       }
         resources[name].provider = provider
       end
+      validate_islast(resources)
+    end
+  end
+
+  def self.validate_islast(resources)
+    islast = {}
+    resources.keys.each do |name|
+      if resources[name][:islast] == true
+        if islast[:suffix].nil?
+          islast[:suffix] = resources[name][:suffix]
+        else
+          raise Puppet::Error, "Multiple 'islast' found for suffix '#{islast[:suffix]}'"
+        end
+      end
     end
   end
 

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -74,10 +74,10 @@ Puppet::Type.
     islast = {}
     resources.keys.each do |name|
       if resources[name][:islast] == true
-        if islast[:suffix].nil?
-          islast[:suffix] = resources[name][:suffix]
+        if islast[resources[name][:suffix]].nil?
+          islast[resources[name][:suffix]] = resources[name][:name]
         else
-          raise Puppet::Error, "Multiple 'islast' found for suffix '#{islast[:suffix]}'"
+          raise Puppet::Error, "Multiple 'islast' found for suffix '#{resources[name][:suffix]}': #{resources[name][:name]} and #{islast[:suffix]}"
         end
       end
     end

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -36,7 +36,7 @@ Puppet::Type.
             islast = false
           end
           i << new(
-            :name     => "#{position} on #{suffix}",
+            :name     => "{#{position}}to #{what} #{access.join(' ')} on #{suffix}",
             :ensure   => :present,
             :position => position,
             :what     => what,
@@ -55,8 +55,14 @@ Puppet::Type.
     accesses = instances
     resources.keys.each do |name|
       if provider = accesses.find{ |access|
-        access.suffix == resources[name][:suffix] &&
-        access.position == resources[name][:position]
+        if resources[name][:position]
+          access.suffix == resources[name][:suffix] &&
+          access.position == resources[name][:position]
+        else
+          access.suffix == resources[name][:suffix] &&
+          access.access == resources[name][:access] &&
+          access.what == resources[name][:what]
+        end
       }
         resources[name].provider = provider
       end

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -11,6 +11,10 @@ Puppet::Type.newtype(:openldap_access) do
     desc "The slapd.conf file"
   end
 
+  newproperty(:islast) do
+    desc "Is this olcAccess the last one?"
+  end
+
   newproperty(:what) do
     desc "The entries and/or attributes to which the access applies"
   end

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -11,35 +11,22 @@ Puppet::Type.newtype(:openldap_access) do
     desc "The slapd.conf file"
   end
 
-  newparam(:what, :namevar => true) do
+  newproperty(:what) do
     desc "The entries and/or attributes to which the access applies"
   end
 
-  newparam(:by, :namevar => true) do
-    desc "To whom the access applies"
-  end
-
-  newparam(:suffix, :namevar => true) do
+  newproperty(:suffix) do
     desc "The suffix to which the access applies"
   end
 
   def self.title_patterns
     [
       [
-        /^(to\s+(\S+)\s+by\s+(.+)\s+on\s+(.+))$/,
+        /^((\S+)\s+on\s+(.+))$/,
         [
           [ :name, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
-          [ :by, lambda{|x| x} ],
+          [ :position, lambda{|x| x} ],
           [ :suffix, lambda{|x| x} ],
-        ],
-      ],
-      [
-        /^(to\s+(\S+)\s+by\s+(.+))$/,
-        [
-          [ :name, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
-          [ :by, lambda{|x| x} ],
         ],
       ],
       [
@@ -51,16 +38,12 @@ Puppet::Type.newtype(:openldap_access) do
     ]
   end
 
-  newparam(:position) do
+  newproperty(:position) do
     desc "Where to place the new entry"
   end
 
-  newproperty(:access) do
+  newproperty(:access, :array_matching => :all) do
     desc "Access rule."
-  end
-
-  newproperty(:control) do
-    desc "Control rule."
   end
 
   autorequire(:openldap_database) do

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -34,7 +34,7 @@ Puppet::Type.newtype(:openldap_access) do
   def self.title_patterns
     [
       [
-        /^({(\d+)}to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
+        /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
         [
           [ :name, lambda{|x| x} ],
           [ :position, lambda{|x| x} ],
@@ -44,7 +44,7 @@ Puppet::Type.newtype(:openldap_access) do
         ],
       ],
       [
-        /^({(\d+)}to\s+(\S+)\s+(by\s+.+)\s+)$/,
+        /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+)\s+)$/,
         [
           [ :name, lambda{|x| x} ],
           [ :position, lambda{|x| x} ],

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -23,6 +23,14 @@ Puppet::Type.newtype(:openldap_access) do
     desc "The suffix to which the access applies"
   end
 
+  newproperty(:position) do
+    desc "Where to place the new entry"
+  end
+
+  newproperty(:access, :array_matching => :all ) do
+    desc "Access rule."
+  end
+
   def self.title_patterns
     [
       [
@@ -76,14 +84,7 @@ Puppet::Type.newtype(:openldap_access) do
         ],
       ],
     ]
-  end
 
-  newproperty(:position) do
-    desc "Where to place the new entry"
-  end
-
-  newproperty(:access, :array_matching => :all) do
-    desc "Access rule."
   end
 
   autorequire(:openldap_database) do

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -26,6 +26,42 @@ Puppet::Type.newtype(:openldap_access) do
   def self.title_patterns
     [
       [
+        /^({(\d+)}to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
+        [
+          [ :name, lambda{|x| x} ],
+          [ :position, lambda{|x| x} ],
+          [ :what, lambda{|x| x} ],
+          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+          [ :suffix, lambda{|x| x} ],
+        ],
+      ],
+      [
+        /^({(\d+)}to\s+(\S+)\s+(by\s+.+)\s+)$/,
+        [
+          [ :name, lambda{|x| x} ],
+          [ :position, lambda{|x| x} ],
+          [ :what, lambda{|x| x} ],
+          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+        ],
+      ],
+      [
+        /^(to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
+        [
+          [ :name, lambda{|x| x} ],
+          [ :what, lambda{|x| x} ],
+          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+          [ :suffix, lambda{|x| x} ],
+        ],
+      ],
+      [
+        /^(to\s+(\S+)\s+(by\s+.+))$/,
+        [
+          [ :name, lambda{|x| x} ],
+          [ :what, lambda{|x| x} ],
+          [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
+        ],
+      ],
+      [
         /^((\S+)\s+on\s+(.+))$/,
         [
           [ :name, lambda{|x| x} ],

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -70,7 +70,7 @@ Puppet::Type.newtype(:openldap_access) do
         ],
       ],
       [
-        /^((\S+)\s+on\s+(.+))$/,
+        /^((\d+)\s+on\s+(.+))$/,
         [
           [ :name, lambda{|x| x} ],
           [ :position, lambda{|x| x} ],

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -5,6 +5,7 @@ define openldap::server::access(
   $what     = undef,
   $suffix   = undef,
   $access   = [],
+  $islast   = false,
 ) {
 
   if ! defined(Class['openldap::server']) {
@@ -29,5 +30,6 @@ define openldap::server::access(
     what     => $what,
     suffix   => $suffix,
     access   => $access,
+    islast   => $islast,
   }
 }

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -4,7 +4,7 @@ define openldap::server::access(
   $position = undef,
   $what     = undef,
   $suffix   = undef,
-  $access   = [],
+  $access   = undef,
   $islast   = false,
 ) {
 

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -3,10 +3,8 @@ define openldap::server::access(
   $ensure   = undef,
   $position = undef,
   $what     = undef,
-  $by       = undef,
   $suffix   = undef,
-  $access   = undef,
-  $control  = undef,
+  $access   = [],
 ) {
 
   if ! defined(Class['openldap::server']) {
@@ -29,9 +27,7 @@ define openldap::server::access(
     provider => $::openldap::server::provider,
     target   => $::openldap::server::conffile,
     what     => $what,
-    by       => $by,
     suffix   => $suffix,
     access   => $access,
-    control  => $control,
   }
 }

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -33,7 +33,7 @@ define openldap::server::access_wrapper (
       {
         "#{position} on #{suffix}" => {
           "position" => position,
-          "what"     => to[/.*to (.*),1],
+          "what"     => to[/.*to (.*)/,1],
           "access"   => access,
           "suffix"   => "#{suffix}",
         }

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -21,8 +21,8 @@
 #     }
 #
 define openldap::server::access_wrapper (
-  $suffix = $name,
   $acl,
+  $suffix = $name,
 ) {
 
   # Parse ACL

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -1,0 +1,42 @@
+define openldap::server::access_wrapper (
+  $hash,
+) {
+  $position = $hash[$name]['position']
+  $what     = $hash[$name]['what']
+  $access   = $hash[$name]['access']
+  $suffix   = $hash[$name]['suffix']
+
+  $count    = count($hash)-1
+
+  if ! is_array($access) {
+    fail('$access variable must be an array')
+  }
+
+  if $position == 0 {  # the first entry
+
+    openldap::server::access { "${position} on ${suffix}" :
+      what   => $what,
+      access => $access,
+    }
+
+  } elsif $position == $count { #the last entry
+
+    $previous_position = $position - 1
+    openldap::server::access { "${position} on ${suffix}" :
+      what    => $what,
+      access  => $access,
+      islast  => true,
+      require => Openldap::Server::Access["${previous_position} on ${suffix}"],
+    }
+
+  } else {
+
+    $previous_position = $position - 1
+    openldap::server::access { "${position} on ${suffix}" :
+      what    => $what,
+      access  => $access,
+      require => Openldap::Server::Access["${previous_position} on ${suffix}"],
+    }
+
+  }
+}

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -44,6 +44,14 @@ define openldap::server::access_wrapper (
   $hash = parseyaml($acl_yaml)
   $hash_keys = keys($hash)
 
+  iterate_access { $hash_keys :
+    hash => $hash,
+  }
+}
+
+define iterate_access(
+  $hash,
+) {
 
   # Call individual openldap::server::access
   $position = $hash[$name]['position']

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -44,52 +44,7 @@ define openldap::server::access_wrapper (
   $hash = parseyaml($acl_yaml)
   $hash_keys = keys($hash)
 
-  iterate_access { $hash_keys :
+  openldap::server::iterate_access { $hash_keys :
     hash => $hash,
-  }
-}
-
-define iterate_access(
-  $hash,
-) {
-
-  # Call individual openldap::server::access
-  $position = $hash[$name]['position']
-  $what     = $hash[$name]['what']
-  $access   = $hash[$name]['access']
-  $suffix   = $hash[$name]['suffix']
-
-  $count    = count($hash)-1
-
-  if ! is_array($access) {
-    fail('$access variable must be an array')
-  }
-
-  if $position == 0 {  # the first entry
-
-    openldap::server::access { "${position} on ${suffix}" :
-      what   => $what,
-      access => $access,
-    }
-
-  } elsif $position == $count { #the last entry
-
-    $previous_position = $position - 1
-    openldap::server::access { "${position} on ${suffix}" :
-      what    => $what,
-      access  => $access,
-      islast  => true,
-      require => Openldap::Server::Access["${previous_position} on ${suffix}"],
-    }
-
-  } else {
-
-    $previous_position = $position - 1
-    openldap::server::access { "${position} on ${suffix}" :
-      what    => $what,
-      access  => $access,
-      require => Openldap::Server::Access["${previous_position} on ${suffix}"],
-    }
-
   }
 }

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -1,6 +1,51 @@
+# == Define openldap::server::access_wrapper
+#
+# Generate access from a given hash.
+#
+# === Parameters
+#
+# [*suffix*]
+#   Default: $name
+#   Mandatory. The suffix to apply acls
+#
+# [*acl*]
+#   Default:
+#   Mandatory. Hash in the form { <what> => <access>, ... }
+#
+#   example:
+#     $acl = {
+#       'to *' => [
+#         'by self write',
+#         'by anonymous read',
+#       ],
+#     }
+#
 define openldap::server::access_wrapper (
-  $hash,
+  $suffix = $name,
+  $acl,
 ) {
+
+  # Parse ACL
+  $acl_yaml = inline_template('<%=
+    position = -1
+    acl.map { |to,access|
+      position = position + 1
+      {
+        "#{position} on #{suffix}" => {
+          "position" => position,
+          "what"     => to[/.*to (.*),1],
+          "access"   => access,
+          "suffix"   => "#{suffix}",
+        }
+      }
+  }.flatten.reduce({}, :update).to_yaml
+  %>')
+
+  $hash = parseyaml($acl_yaml)
+  $hash_keys = keys($hash)
+
+
+  # Call individual openldap::server::access
   $position = $hash[$name]['position']
   $what     = $hash[$name]['what']
   $access   = $hash[$name]['access']

--- a/manifests/server/iterate_access.pp
+++ b/manifests/server/iterate_access.pp
@@ -1,0 +1,45 @@
+#  This is a 'private' class used by openldap::server::access_wrapper
+define openldap::server::iterate_access(
+  $hash,
+) {
+
+  # Call individual openldap::server::access
+  $position = $hash[$name]['position']
+  $what     = $hash[$name]['what']
+  $access   = $hash[$name]['access']
+  $suffix   = $hash[$name]['suffix']
+
+  $count    = count($hash)-1
+
+  if ! is_array($access) {
+    fail('$access variable must be an array')
+  }
+
+  if $position == 0 {  # the first entry
+
+    openldap::server::access { "${position} on ${suffix}" :
+      what   => $what,
+      access => $access,
+    }
+
+  } elsif $position == $count { #the last entry
+
+    $previous_position = $position - 1
+    openldap::server::access { "${position} on ${suffix}" :
+      what    => $what,
+      access  => $access,
+      islast  => true,
+      require => Openldap::Server::Access["${previous_position} on ${suffix}"],
+    }
+
+  } else {
+
+    $previous_position = $position - 1
+    openldap::server::access { "${position} on ${suffix}" :
+      what    => $what,
+      access  => $access,
+      require => Openldap::Server::Access["${previous_position} on ${suffix}"],
+    }
+
+  }
+}

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -135,7 +135,7 @@ describe 'openldap::server::database' do
     end
 
     it 'can connect with ldapsearch to the new password' do
-      ldapsearch('-LLL -x -b "cn=config" -D "cn=newadmin,cn=config" -w newsecret') do |r|
+      ldapsearch('-LLL -s base -x -b "cn=config" -D "cn=newadmin,cn=config" -w newsecret') do |r|
         expect(r.stdout).to match(/dn: cn=config/)
       end
     end

--- a/spec/acceptance/openldap__server__access_spec.rb
+++ b/spec/acceptance/openldap__server__access_spec.rb
@@ -30,7 +30,7 @@ describe 'openldap::server::access' do
         class { 'openldap::server': }
         openldap::server::database { 'dc=example,dc=com' : }
         ::openldap::server::access { 'admin':
-          what    => 'attrs=userPassword,shadowLastChange',
+          what    => 'attrs=userPassword,distinguishedName',
           access  => ['by dn="cn=admin,dc=example,dc=com" write'],
           suffix  => 'dc=example,dc=com',
           require => Openldap::Server::Database['dc=example,dc=com'],

--- a/spec/acceptance/openldap__server__access_spec.rb
+++ b/spec/acceptance/openldap__server__access_spec.rb
@@ -2,14 +2,38 @@ require 'spec_helper_acceptance'
 
 describe 'openldap::server::access' do
 
+  before :all do
+    pp = <<-EOS
+      class { 'openldap::server': }
+      openldap::server::database { 'dc=example,dc=com':
+        ensure => absent,
+      }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+  after :all do
+    pp = <<-EOS
+      class { 'openldap::server': }
+      openldap::server::database { 'dc=example,dc=com': ensure => absent, }
+    EOS
+
+    apply_manifest(pp, :expect_changes => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
   context 'with defaults' do
     it 'should idempotently run' do
       pp = <<-EOS
         class { 'openldap::server': }
+        openldap::server::database { 'dc=example,dc=com' : }
         ::openldap::server::access { 'admin':
-          what   => 'attrs=userPassword,shadowLastChange',
-          by     => 'dn="cn=admin,dc=example,dc=com"',
-          suffix => 'dc=example,dc=com',
+          what    => 'attrs=userPassword,shadowLastChange',
+          access  => ['by dn="cn=admin,dc=example,dc=com" write'],
+          suffix  => 'dc=example,dc=com',
+          require => Openldap::Server::Database['dc=example,dc=com'],
         }
       EOS
 

--- a/spec/defines/openldap_server_access_spec.rb
+++ b/spec/defines/openldap_server_access_spec.rb
@@ -58,6 +58,38 @@ describe 'openldap::server::access' do
           is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
         }
       end
+
+      context 'with composite namevar with position' do
+        let(:title) {
+          '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
+        }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_openldap_access('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
+        }
+      end
+
+      context 'with access as an array' do
+        let(:params) do
+          {
+            :position => '0',
+            :what     => 'to attrs=userPassword,shadowLastChange',
+            :suffix   => 'dc=example,dc=com',
+            :access   => [
+              'by dn="cn=admin,dc=example,dc=com" write',
+              'by anonymous read',
+            ]
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_openldap_access('foo').
+             with_position('0').
+             with_what('to attrs=userPassword,shadowLastChange').
+             with_suffix('dc=example,dc=com').
+             with_access(['by dn="cn=admin,dc=example,dc=com" write','by anonymous read'])
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed on #54 , here is my refactor for using an array for defining access.

I would like to have comments about this before trying to write the acceptance and unit tests, so i won't write them multiple times.

Here is the new syntax.  Unfortunately, i wasn't able to keep the old syntax as well :(

```
openldap::server::access { '0 on dc=example,dc=com' :
  what     => '*',
  access   =>  [
    'by dn.exact="cn=admin,dc=example,dc=com" write',
    'by * none break',
  ]
```

And as my precedent pull request, i've also included a wrapper for giving a hash to this submodule.  It is documented into the README.md