### PR TITLE
Allow creation of database named 'cn=*'

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -163,7 +163,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
     t << "objectClass: dcObject\n" if resource[:suffix].start_with?("dc=")
     t << "objectClass: organization\n"
     t << "dc: #{resource[:suffix].split(/,?dc=/).delete_if { |c| c.empty? }[0]}\n" if resource[:suffix].start_with?("dc=")
-    t << "o: #{resource[:suffix].split(/,?dc=/).delete_if { |c| c.empty? }.join('.')}\n" if resource[:suffix].start_with?("dc=")
+    t << "o: #{resource[:suffix].split(/,?(dc|cn)=/).delete_if { |c| c.empty? }.join('.')}\n" if resource[:suffix].start_with?("dc=","cn=")
     t << "\n"
     t << "dn: cn=admin,#{resource[:suffix]}\n"
     t << "objectClass: simpleSecurityObject\n" if resource[:rootpw]
@@ -366,7 +366,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
       rescue Exception => e
         raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
       end
-      initdb if @property_flush[:directory]
+      initdb if @property_flush[:directory] and resource[:initdb] != false
     end
     @property_hash = resource.to_hash
   end

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -92,8 +92,8 @@ describe 'openldap::server::database' do
     end
 
     it 'can connect with ldapsearch' do
-      ldapsearch('-LLL -x -b "dc=foo,dc=com" -D "cn=admin,dc=bar,dc=com" -w secret') do |r|
-        expect(r.stdout).to match(/dn: dc=foo,dc=com/)
+      ldapsearch('-LLL -x -b "dc=bar,dc=com" -D "cn=admin,dc=bar,dc=com" -w secret') do |r|
+        expect(r.stdout).to match(/dn: dc=bar,dc=com/)
       end
     end
   end

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -21,7 +21,7 @@ describe 'openldap::server::database' do
   after :all do
     pp = <<-EOS
       class { 'openldap::server': }
-      openldap::server::database { ['dc=foo,dc=com', 'dc=bar,dc=com']:
+      openldap::server::database { ['dc=foo,dc=com', 'dc=bar,dc=com', 'cn=log']:
         ensure => absent,
       }
       openldap::server::database { 'cn=config':
@@ -95,6 +95,35 @@ describe 'openldap::server::database' do
       ldapsearch('-LLL -x -b "dc=foo,dc=com" -D "cn=admin,dc=bar,dc=com" -w secret') do |r|
         expect(r.stdout).to match(/dn: dc=foo,dc=com/)
       end
+    end
+  end
+
+  context 'with a log db' do
+    it 'creates a log database' do
+      pp = <<-EOS
+      class {'openldap::server': }
+      openldap::server::module {'accesslog':
+        ensure  => present,
+      }
+      openldap::server::database { 'cn=log':
+        ensure  => present,
+        initdb  => false,
+      }
+      openldap::server::overlay { 'accesslog on cn=config' :
+        ensure  => present,
+        require => [
+          Openldap::Server::Module['accesslog'],
+          Openldap::Server::Database['cn=log'],
+        ],
+        options => {
+          'olcAccessLogDB' => 'cn=log',
+        }
+      }
+
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
     end
   end
 


### PR DESCRIPTION
while messing with the accesslog overlay, creation of database named 'cn=log' was not implemented...

In their [example](http://www.openldap.org/software/man.cgi?query=slapo-accesslog&apropos=0&sektion=0&manpath=OpenLDAP+2.4-Release&format=html):
```
database bdb
suffix cn=log
...
index reqStart eq
access to *
  by dn.base="cn=admin,dc=example,dc=com" read
```