### PR TITLE
fixed bug for spaces in the "by" section of the rule

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -26,7 +26,7 @@ Puppet::Type.
         when /^olcAccess: /
           position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?)(\s+by\s+.*)+$/).captures
           bys.split(' by ')[1..-1].each { |b|
-            by, access, control = b.strip.match(/^(\S+)\s+(\S+)(\s+\S+)?$/).captures
+            by, access, control = b.strip.match(/^(\S+\"[^\"]+\"|\S+)\s+(\S+)(\s+\S+)?$/).captures
             i << new(
               :name     => "to #{what} by #{by} on #{suffix}",
               :ensure   => :present,


### PR DESCRIPTION
# Problem

When creating openldap_access rules, it's possible to have a space in the "by" section of the rule.  This currently breaks the instances method in the provider which matches soley on space delimited lines.

# Example

I declare this code in Puppet

    openldap_access { 'to dn.subtree="dc=example,dc=com" by group/groupOfNames/member.exact="cn=slapd replicas,ou=groups,dc=example,dc=com" on dc=example,dc=com':
      ensure => 'present',
      access => 'read',
    }

The opendap module configures this correctly in LDAP, a look at the cn=config LDIF gives us

    olcAccess: {6}to dn.subtree="dc=example,dc=com" by group/groupOfNames/member.exa
    ct="cn=slapd replicas,ou=groups,dc=example,dc=com" read

If we try and run Puppet again now, it will try and re-create this rule and LDAP bombs out with an error because it already exists.  The reason for this is the prefetch,  if we use puppet resource to look at this entry we can see it's broken....

    # puppet resource openldap_access

    openldap_access { 'to dn.subtree="dc=example,dc=com" by group/groupOfNames/member.exact="cn=slapd on dc=example,dc=com':
      ensure  => 'present',
      access  => 'replicas,ou=groups,dc=example,dc=com"',
      control => ' read',
    }

# Cause/Fix

The problem is in the regex in the prefix that deals with the by, access, control line

```ruby
by, access, control = b.strip.match(/^(\S+)\s+(\S+)(\s+\S+)?$/).captures
```

This regex will break if there is a space in the by section.  Since we can assume that if there is a space then it will be quoted, the regex in this PR should support all possible combinations, so 

    foo=a,b,c x y
    foo=a,b,c x
    foo="a b c" x y
    foo="a b c" x
    foo="a c" x
    foo x
    foo x y

In all of these examples, x should be the second match and y (if it exists) the third match.  I've tested this PR against a variety of scenarios and it seems to work.





