### PR TITLE
support for adding access based on olcDatabase

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -24,8 +24,8 @@ Puppet::Type.type(:openldap_access).provide(:olc) do
       position = nil
       paragraph.gsub("\n ", '').split("\n").collect do |line|
         case line
-        when /^olcSuffix: /
-          suffix = line.split(' ')[1]
+        when /^olc(Suffix|Database): /
+          suffix = line.split(' ')[1].gsub(/\{\d+\}/, '')
         when /^olcAccess: /
           position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+)(\s+by\s+.*)+$/).captures
           bys.split(' by ')[1..-1].each { |b|
@@ -62,7 +62,7 @@ Puppet::Type.type(:openldap_access).provide(:olc) do
       '-b',
       'cn=config',
       '-H',
-      "ldap:///???(olcSuffix=#{suffix})"
+      "ldap:///???(|(olcSuffix=#{suffix})(olcDatabase=#{suffix}))"
     ).split("\n").collect do |line|
       if line =~ /^dn: /
         return line.split(' ')[1]


### PR DESCRIPTION

This was discussed with @mcanevet over IRC - the problem arose when trying to add access rules to databases such as "monitor"..... eg

    openldap_access { 'to dn.subtree="cn=monitor" by users on monitor':
      ensure => present,
      access => 'read',
    }

The `getDn` method failed to determine the dn for monitor, since it uses `olcSuffix` to search on, resulting in an invalid DN error from LDAP.  @mcanevet 's suggestion was to try searching on olcDatabase too in order to match it correctly.  This works, and I also had to update the `instances` method to be able to match on `olc(Suffix|Database)` and strip away the curly braces in the case of a database.   This works, and is idempotent, for the above example.
