### PR TITLE
Fix for frontend and config databases

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -91,7 +91,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
         end
       end
       if backend == 'monitor' and !suffix
-        suffix = 'cn=Monitor'
+        suffix = 'cn=monitor'
       end
       if backend == 'config' and !suffix
         suffix = 'cn=config'

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -105,7 +105,7 @@ describe 'openldap::server::database' do
       openldap::server::module {'back_monitor':
         ensure => present,
       }
-      openldap::server::database { 'cn=Monitor':
+      openldap::server::database { 'cn=monitor':
         ensure => present,
         backend => 'monitor',
         require => Openldap::Server::Module['back_monitor'],


### PR DESCRIPTION
@crayfishx @mcanevet 

About #108 
I though about using the syntax where `suffix => 'cn=config'` as in 96eef890ce8cad7b4bb33ef2aa20e3e16bfe796f

but this commit makes `suffix => 'config'` and `suffix => 'monitor'` and break consistency with
puppet-openldap/lib/puppet/provider/openldap_database/olc.rb line 93:
```
      if backend == 'monitor' and !suffix
        suffix = 'cn=Monitor'
      end
      if backend == 'config' and !suffix
        suffix = 'cn=config'
      end
```

It also break the {-1}frontend database as `slapcat -b cn=config -H ldap:///???(olcDatabase=frontend)` does not return anything...  What do you think about using `suffix => 'cn=monitor'` like in the database provider?

And i'm not sure also of positions of olcSuffix and olcDatabase because we do not want to have `suffix => 'hdm'`

But wow, getdn gets ugly... :(  Would you have another idea?