### PR TITLE
In Ruby 1.8.7, Hash.select returns an array

### DIFF
--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -155,7 +155,7 @@ Puppet::Type.
       if @property_flush[:options] then
         if @property_hash[:options]
           # Remove all previously options remove in the should
-          @property_hash[:options].select { |key, value| !@property_flush[:options].member?(key) }.keys.each do |k|
+          Hash[@property_hash[:options].select { |key, value| !@property_flush[:options].member?(key) }].keys.each do |k|
             t << "delete: #{k}\n-\n"
           end
         end


### PR DESCRIPTION
Ruby 1.8.7 is very unsupported, but that is how puppet runs on CentOS 6.
