### PR TITLE
Allow a complex what section in an openldap access control statement.

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:openldap_access).provide(:olc) do
         when /^olcSuffix: /
           suffix = line.split(' ')[1]
         when /^olcAccess: /
-          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+)(\s+by\s+.*)+$/).captures
+          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?)(\s+by\s+.*)+$/).captures
           bys.split(' by ')[1..-1].each { |b|
             by, access, control = b.strip.match(/^(\S+)\s+(\S+)(\s+\S+)?$/).captures
             i << new(

--- a/spec/defines/openldap_server_access_spec.rb
+++ b/spec/defines/openldap_server_access_spec.rb
@@ -29,6 +29,39 @@ describe 'openldap::server::access' do
           is_expected.to contain_openldap_access('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
         }
       end
+
+      context 'with composite namevar, what includes dn and filter' do
+        let(:title) {
+          'to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
+        }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          skip('Should work')
+          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
+        }
+      end
+
+      context 'with composite namevar, what includes dn and attrs' do
+        let(:title) {
+          'to dn.one="ou=users,dc=example,dc=com" attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
+        }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          skip('Should work')
+          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
+        }
+      end
+
+      context 'with composite namevar, what includes dn, filter and attrs' do
+        let(:title) {
+          'to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
+        }
+        it { is_expected.to compile.with_all_deps }
+        it {
+          skip('Should work')
+          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
+        }
+      end
     end
   end
 end

--- a/spec/defines/openldap_server_access_spec.rb
+++ b/spec/defines/openldap_server_access_spec.rb
@@ -25,8 +25,7 @@ describe 'openldap::server::access' do
         }
         it { is_expected.to compile.with_all_deps }
         it {
-          skip('Should work')
-          is_expected.to contain_openldap_access('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
+          is_expected.to contain_openldap_access('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
         }
       end
 
@@ -36,8 +35,7 @@ describe 'openldap::server::access' do
         }
         it { is_expected.to compile.with_all_deps }
         it {
-          skip('Should work')
-          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
+          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
         }
       end
 
@@ -47,8 +45,7 @@ describe 'openldap::server::access' do
         }
         it { is_expected.to compile.with_all_deps }
         it {
-          skip('Should work')
-          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
+          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
         }
       end
 
@@ -58,8 +55,7 @@ describe 'openldap::server::access' do
         }
         it { is_expected.to compile.with_all_deps }
         it {
-          skip('Should work')
-          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com').that_requires('Openldap_database[dc=example,dc=com]')
+          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
         }
       end
     end


### PR DESCRIPTION
This allows dn, filter, and attrs to be defined for the what section of an openldap access control statement concurrently.
http://www.openldap.org/doc/admin24/access-control.html