### PR TITLE
Fixed an idempotency issue on the syncrepl variable

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:openldap_database).provide(:olc) do
         when /^olcSyncrepl: /
           syncrepl ||= []
           optvalue = line.split(' ',2)[1]
-          syncrepl.push(optvalue.match(/^(\{\d+\})?(.+)$/).captures[1])
+          syncrepl.push(optvalue.match(/^(\{\d+\})?(.+)$/).captures[1]+"\n")
         when /^olcLimits: /
           limit = line.match(/^olcLimits:\s+(\{\d+\})?(.+)$/).captures[1]
           limits << limit


### PR DESCRIPTION
I had an idempotency issue when I was setting a value for syncrepl on a openldap_database resource :

```bash
Notice: /Stage[main]/Openldap::Server::Database[dc=example,dc=org]/Openldap_database[dc=example,dc=org]/syncrepl: syncrepl changed ['rid=001 provider=ldap://ldap.example.org:389"'] to 'rid=001 provider=ldap://ldap.example.org:389"
```

Here is my definition, I have a custom profile to manage it through Hiera :

```yaml
profiles::openldap::server::databases:
  'dc=example,dc=org':
    syncrepl:
      - >
        rid=001
        provider=ldap://ldap.example.org:389

```

My profile basically does:

```puppet
create_resources( openldap::server::database, $databases, $defaults )
```