### PR TITLE
Add base provider that implements common commands and methods and use it

### DIFF
--- a/lib/puppet/provider/openldap.rb
+++ b/lib/puppet/provider/openldap.rb
@@ -1,0 +1,134 @@
+require 'tempfile'
+
+class Puppet::Provider::Openldap < Puppet::Provider
+
+  initvars # without this, commands won't work
+
+  commands :original_slapcat    => 'slapcat',
+           :original_ldapmodify => 'ldapmodify',
+           :original_ldapadd    => 'ldapadd'
+
+  def self.slapcat(filter, dn = '', base = 'cn=config')
+    arguments = [
+      '-b', base,
+      '-o', 'ldif-wrap=no',
+      '-H', "ldap:///#{dn}???#{filter}"
+    ]
+
+    if 'squeeze' == Facter.value(:lsbdistcodename)
+      arguments = [
+        '-b', base,
+        '-H', "ldap:///#{dn}???#{filter}"
+      ]
+    end
+
+    original_slapcat(*arguments)
+  end
+  def slapcat(*args); self.class.slapcat(*args); end
+
+  def self.ldapadd(path)
+    original_ldapadd('-cQY', 'EXTERNAL', '-H', 'ldapi:///', '-f', path)
+  end
+  def ldapadd(*args); self.class.ldapadd(*args); end
+
+  # Unwrap LDIF and return each attribute beginning with "olc" also removing
+  # that occurance of "olc" at the beginning.
+  def self.get_lines(items)
+    items.strip.
+      gsub("\n ", "").
+      split("\n").
+      select  { |entry| entry =~ /^olc/ }.
+      collect { |entry| entry.gsub(/^olc/, '') }
+  end
+  def get_lines(*args); self.class.get_lines(*args); end
+
+  # Unwrap LDIF and return each entry as array of lines.
+  #
+  # Example LDIF:
+  #   dn: cn=config
+  #   ...
+  #
+  #   dn: cn=schema,cn=config
+  #   ...
+  #
+  # Results in:
+  #
+  #   [['dn: cn=config', '...'],
+  #    ['dn: cn=schema,cn=config', '...']]
+  #
+  def self.get_entries(items)
+    items.strip.
+      split("\n\n").
+      collect { |paragraph|
+        paragraph.
+          gsub("\n ", '').
+          split("\n")
+      }
+  end
+  def get_entries(*args); self.class.get_entries(*args); end
+
+  def self.last_of_split(line, by = ' ')
+    line.split(by, 2).last
+  end
+  def last_of_split(*args); self.class.last_of_split(*args); end
+
+  def self.ldapmodify(path)
+    original_ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', path)
+  end
+  def ldapmodify(*args); self.class.ldapmodify(*args); end
+
+  def self.temp_ldif(name = 'openldap_ldif')
+    Tempfile.new(name)
+  end
+  def temp_ldif(*args); self.class.temp_ldif(*args); end
+
+  def delimit       ; "-\n"                 ; end
+  def cn_config     ; dn('cn=config')       ; end
+  def dn(dn)        ; "dn: #{dn}\n"         ; end
+  def changetype(t) ; "changetype: #{t}\n"  ; end
+  def add(key)      ; "add: olc#{key}\n"    ; end
+  def del(key)      ; "delete: olc#{key}\n" ; end
+
+  def replace_key(key)
+    "replace: olc#{key}\n"
+  end
+
+  def key_value(key, value)
+    "olc#{key}: #{value}\n"
+  end
+
+  def add_or_replace_key(key, force_replace = :false)
+    # This list of possible attributes of cn=config has been extracted from a
+    # running slapd with the following command:
+    #   ldapsearch -s base -b cn=Subschema attributeTypes -o ldif-wrap=no | \
+    #     grep SINGLE-VALUE | grep "NAME 'olc" | \
+    #     sed -e "s|.*NAME '||g" \
+    #         -e "s|' SYNTAX.*||g" \
+    #         -e "s|' EQUALITY.*||g" \
+    #         -e "s|' DESC.*||g"
+
+    single_value_attributes = %w[ConfigFile ConfigDir AddContentAcl ArgsFile
+      AuthzPolicy Backend Concurrency ConnMaxPending ConnMaxPendingAuth Database
+      DefaultSearchBase GentleHUP Hidden IdleTimeout IndexSubstrIfMinLen
+      IndexSubstrIfMaxLen IndexSubstrAnyLen IndexSubstrAnyStep IndexIntLen LastMod
+      ListenerThreads LocalSSF LogFile MaxDerefDepth MirrorMode ModulePath Monitoring
+      Overlay PasswordCryptSaltFormat PidFile PluginLogFile ReadOnly Referral
+      ReplicaArgsFile ReplicaPidFile ReplicationInterval ReplogFile ReverseLookup
+      RootDN RootPW SaslAuxprops SaslHost SaslRealm SaslSecProps SchemaDN SizeLimit
+      SockbufMaxIncoming SockbufMaxIncomingAuth Subordinate SyncUseSubentry Threads
+      TLSCACertificateFile TLSCACertificatePath TLSCertificateFile
+      TLSCertificateKeyFile TLSCipherSuite TLSCRLCheck TLSCRLFile TLSRandFile
+      TLSVerifyClient TLSDHParamFile TLSProtocolMin ToolThreads UpdateDN WriteTimeout
+      DbDirectory DbCheckpoint DbNoSync DbMaxReaders DbMaxSize DbMode DbSearchStack
+      PPolicyDefault PPolicyHashCleartext PPolicyForwardUpdates PPolicyUseLockout
+      MemberOfDN MemberOfDangling MemberOfRefInt MemberOfGroupOC MemberOfMemberAD
+      MemberOfMemberOfAD MemberOfDanglingError SpCheckpoint SpSessionlog SpNoPresent
+      SpReloadHint]
+
+    use_replace = single_value_attributes.include?(key.to_s) || force_replace == :true
+
+    return use_replace ?
+      replace_key(key) :
+      add(key)
+  end
+end

--- a/lib/puppet/provider/openldap.rb
+++ b/lib/puppet/provider/openldap.rb
@@ -106,24 +106,95 @@ class Puppet::Provider::Openldap < Puppet::Provider
     #         -e "s|' SYNTAX.*||g" \
     #         -e "s|' EQUALITY.*||g" \
     #         -e "s|' DESC.*||g"
-
-    single_value_attributes = %w[ConfigFile ConfigDir AddContentAcl ArgsFile
-      AuthzPolicy Backend Concurrency ConnMaxPending ConnMaxPendingAuth Database
-      DefaultSearchBase GentleHUP Hidden IdleTimeout IndexSubstrIfMinLen
-      IndexSubstrIfMaxLen IndexSubstrAnyLen IndexSubstrAnyStep IndexIntLen LastMod
-      ListenerThreads LocalSSF LogFile MaxDerefDepth MirrorMode ModulePath Monitoring
-      Overlay PasswordCryptSaltFormat PidFile PluginLogFile ReadOnly Referral
-      ReplicaArgsFile ReplicaPidFile ReplicationInterval ReplogFile ReverseLookup
-      RootDN RootPW SaslAuxprops SaslHost SaslRealm SaslSecProps SchemaDN SizeLimit
-      SockbufMaxIncoming SockbufMaxIncomingAuth Subordinate SyncUseSubentry Threads
-      TLSCACertificateFile TLSCACertificatePath TLSCertificateFile
-      TLSCertificateKeyFile TLSCipherSuite TLSCRLCheck TLSCRLFile TLSRandFile
-      TLSVerifyClient TLSDHParamFile TLSProtocolMin ToolThreads UpdateDN WriteTimeout
-      DbDirectory DbCheckpoint DbNoSync DbMaxReaders DbMaxSize DbMode DbSearchStack
-      PPolicyDefault PPolicyHashCleartext PPolicyForwardUpdates PPolicyUseLockout
-      MemberOfDN MemberOfDangling MemberOfRefInt MemberOfGroupOC MemberOfMemberAD
-      MemberOfMemberOfAD MemberOfDanglingError SpCheckpoint SpSessionlog SpNoPresent
-      SpReloadHint]
+    single_value_attributes = %w[
+      ConfigFile
+      ConfigDir
+      AddContentAcl
+      ArgsFile
+      AuthzPolicy
+      Backend
+      Concurrency
+      ConnMaxPending
+      ConnMaxPendingAuth
+      Database
+      DefaultSearchBase
+      GentleHUP
+      Hidden
+      IdleTimeout
+      IndexSubstrIfMinLen
+      IndexSubstrIfMaxLen
+      IndexSubstrAnyLen
+      IndexSubstrAnyStep
+      IndexIntLen
+      LastMod
+      ListenerThreads
+      LocalSSF
+      LogFile
+      MaxDerefDepth
+      MirrorMode
+      ModulePath
+      Monitoring
+      Overlay
+      PasswordCryptSaltFormat
+      PidFile
+      PluginLogFile
+      ReadOnly
+      Referral
+      ReplicaArgsFile
+      ReplicaPidFile
+      ReplicationInterval
+      ReplogFile
+      ReverseLookup
+      RootDN
+      RootPW
+      SaslAuxprops
+      SaslHost
+      SaslRealm
+      SaslSecProps
+      SchemaDN
+      SizeLimit
+      SockbufMaxIncoming
+      SockbufMaxIncomingAuth
+      Subordinate
+      SyncUseSubentry
+      Threads
+      TLSCACertificateFile
+      TLSCACertificatePath
+      TLSCertificateFile
+      TLSCertificateKeyFile
+      TLSCipherSuite
+      TLSCRLCheck
+      TLSCRLFile
+      TLSRandFile
+      TLSVerifyClient
+      TLSDHParamFile
+      TLSProtocolMin
+      ToolThreads
+      UpdateDN
+      WriteTimeout
+      DbDirectory
+      DbCheckpoint
+      DbNoSync
+      DbMaxReaders
+      DbMaxSize
+      DbMode
+      DbSearchStack
+      PPolicyDefault
+      PPolicyHashCleartext
+      PPolicyForwardUpdates
+      PPolicyUseLockout
+      MemberOfDN
+      MemberOfDangling
+      MemberOfRefInt
+      MemberOfGroupOC
+      MemberOfMemberAD
+      MemberOfMemberOfAD
+      MemberOfDanglingError
+      SpCheckpoint
+      SpSessionlog
+      SpNoPresent
+      SpReloadHint
+    ]
 
     use_replace = single_value_attributes.include?(key.to_s) || force_replace == :true
 

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -1,24 +1,19 @@
 require 'tempfile'
 
-Puppet::Type.type(:openldap_access).provide(:olc) do
+Puppet::Type.
+  type(:openldap_access).
+  provide(:olc, :parent => Puppet::Provider::Openldap) do
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
   defaultfor :osfamily => :debian, :osfamily => :redhat
-
-  commands :slapcat => 'slapcat', :ldapmodify => 'ldapmodify'
 
   mk_resource_methods
 
   def self.instances
     # TODO: restict to bdb, hdb and globals
     i = []
-    slapcat(
-      '-b',
-      'cn=config',
-      '-H',
-      'ldap:///???(olcAccess=*)'
-    ).split("\n\n").collect do |paragraph|
+    slapcat('(olcAccess=*)').split("\n\n").collect do |paragraph|
       access = nil
       suffix = nil
       position = nil
@@ -69,23 +64,13 @@ Puppet::Type.type(:openldap_access).provide(:olc) do
     elsif suffix == 'cn=config'
       return 'olcDatabase={0}config,cn=config'
     elsif suffix == 'cn=monitor'
-      slapcat(
-        '-b',
-        'cn=config',
-        '-H',
-        "ldap:///???(olcDatabase=monitor)"
-      ).split("\n").collect do |line|
+      slapcat('(olcDatabase=monitor)').split("\n").collect do |line|
         if line =~ /^dn: /
           return line.split(' ')[1]
         end
       end
     else
-      slapcat(
-        '-b',
-        'cn=config',
-        '-H',
-        "ldap:///???(olcSuffix=#{suffix})"
-      ).split("\n").collect do |line|
+      slapcat("(olcSuffix=#{suffix})").split("\n").collect do |line|
         if line =~ /^dn: /
           return line.split(' ')[1]
         end
@@ -106,7 +91,7 @@ Puppet::Type.type(:openldap_access).provide(:olc) do
     t.close
     Puppet.debug(IO.read t.path)
     begin
-      ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end
@@ -135,7 +120,7 @@ Puppet::Type.type(:openldap_access).provide(:olc) do
     t.close
     Puppet.debug(IO.read t.path)
     begin
-      ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end

--- a/lib/puppet/provider/openldap_dbindex/olc.rb
+++ b/lib/puppet/provider/openldap_dbindex/olc.rb
@@ -1,24 +1,19 @@
-require 'tempfile'
+require File.expand_path(File.join(File.dirname(__FILE__), %w[.. openldap]))
 
-Puppet::Type.type(:openldap_dbindex).provide(:olc) do
+Puppet::Type.
+  type(:openldap_dbindex).
+  provide(:olc, :parent => Puppet::Provider::Openldap) do
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
   defaultfor :osfamily => :debian, :osfamily => :redhat
-
-  commands :slapcat => 'slapcat', :ldapmodify => 'ldapmodify'
 
   mk_resource_methods
 
   def self.instances
     # TODO: restict to bdb and hdb
     i = []
-    slapcat(
-      '-b',
-      'cn=config',
-      '-H',
-      'ldap:///???(olcDbIndex=*)'
-    ).split("\n\n").collect do |paragraph|
+    slapcat('(olcDbIndex=*)').split("\n\n").collect do |paragraph|
       suffix = nil
       attrlist = nil
       indices = nil
@@ -56,12 +51,7 @@ Puppet::Type.type(:openldap_dbindex).provide(:olc) do
   end
 
   def getDn(suffix)
-    slapcat(
-      '-b',
-      'cn=config',
-      '-H',
-      "ldap:///???(olcSuffix=#{suffix})"
-    ).split("\n").collect do |line|
+    slapcat("(olcSuffix=#{suffix})").split("\n").collect do |line|
       if line =~ /^dn: /
         return line.split(' ')[1]
       end
@@ -80,7 +70,7 @@ Puppet::Type.type(:openldap_dbindex).provide(:olc) do
     t.close
     Puppet.debug(IO.read t.path)
     begin
-      ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end
@@ -103,7 +93,7 @@ Puppet::Type.type(:openldap_dbindex).provide(:olc) do
     t.close
     Puppet.debug(IO.read t.path)
     begin
-    ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+    ldapmodify(t.path)
     rescue Exception => e
     raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end
@@ -111,10 +101,7 @@ Puppet::Type.type(:openldap_dbindex).provide(:olc) do
 
   def getCurrentOlcDbIndex(suffix)
     i = []
-    slapcat(
-      '-H',
-      "ldap:///#{getDn(suffix)}???(olcDbIndex=*)"
-    ).split("\n\n").collect do |paragraph|
+    slapcat("(olcDbIndex=*)", getDn(suffix)).split("\n\n").collect do |paragraph|
       paragraph.gsub("\n ", '').split("\n").collect do |line|
         case line
         when /^olcDbIndex: /

--- a/lib/puppet/provider/openldap_global_conf/olc.rb
+++ b/lib/puppet/provider/openldap_global_conf/olc.rb
@@ -1,22 +1,17 @@
-require 'tempfile'
+require File.expand_path(File.join(File.dirname(__FILE__), %w[.. openldap]))
 
-Puppet::Type.type(:openldap_global_conf).provide(:olc) do
+Puppet::Type.
+  type(:openldap_global_conf).
+  provide(:olc, :parent => Puppet::Provider::Openldap) do
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
   defaultfor :osfamily => :debian, :osfamily => :redhat
 
-  commands :slapcat => 'slapcat', :ldapmodify => 'ldapmodify'
-
   mk_resource_methods
 
   def self.instances
-    items = slapcat(
-      '-b',
-      'cn=config',
-      '-H',
-      'ldap:///???(objectClass=olcGlobal)'
-    )
+    items = slapcat('(objectClass=olcGlobal)')
     items.gsub("\n ", "").split("\n").select{|e| e =~ /^olc/}.collect do |line|
       name, value = line.split(': ')
       # initialize @property_hash
@@ -61,7 +56,7 @@ Puppet::Type.type(:openldap_global_conf).provide(:olc) do
     t.close
     Puppet.debug(IO.read t.path)
     begin
-      ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end
@@ -82,7 +77,7 @@ Puppet::Type.type(:openldap_global_conf).provide(:olc) do
     t.close
     Puppet.debug(IO.read t.path)
     begin
-      ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end
@@ -117,7 +112,7 @@ Puppet::Type.type(:openldap_global_conf).provide(:olc) do
     t.close
     Puppet.debug(IO.read t.path)
     begin
-      ldapmodify('-Y', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end

--- a/lib/puppet/provider/openldap_schema/olc.rb
+++ b/lib/puppet/provider/openldap_schema/olc.rb
@@ -1,18 +1,18 @@
-require 'tempfile'
+require File.expand_path(File.join(File.dirname(__FILE__), %w[.. openldap]))
 
-Puppet::Type.type(:openldap_schema).provide(:olc) do
+Puppet::Type.
+  type(:openldap_schema).
+  provide(:olc, :parent => Puppet::Provider::Openldap) do
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
   defaultfor :osfamily => :debian, :osfamily => :redhat
 
-  commands :slapcat => 'slapcat', :ldapadd => 'ldapadd'
-
   mk_resource_methods
 
   def self.instances
     schemas = []
-    slapcat('-H', 'ldap:///???(objectClass=olcSchemaConfig)', '-b', 'cn=config').split("\n\n").each do |paragraph|
+    slapcat('(objectClass=olcSchemaConfig)').split("\n\n").each do |paragraph|
       paragraph.split("\n").each do |line|
         if line =~ /^cn: \{/
           schemas.push line
@@ -75,7 +75,7 @@ Puppet::Type.type(:openldap_schema).provide(:olc) do
         t << schema
       end
       t.close
-      ldapadd('-cQY', 'EXTERNAL', '-H', 'ldapi:///', '-f', t.path)
+      ldapadd(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{IO.read t.path}\nError message: #{e.message}"
     end


### PR DESCRIPTION
The command slapcat, ldapmodify and ldapadd are now methods in the base
provider. This means their mostly identical arguments can be changed in one
place and invoking any of the commands means only passing the necessary
parameters.