### PR TITLE
Added option to disable removal of default database

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -18,6 +18,7 @@ class openldap::server(
   $ssl_ca    = undef,
 
   $databases = {},
+  $remove_default_databases = true,
 
   $ldap_ifs  = ['/'],
   $ldaps_ifs = [],

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -51,8 +51,10 @@ class openldap::server::slapdconf {
     fail 'You must specify a ssl_cert'
   }
 
-  openldap::server::database { 'dc=my-domain,dc=com':
-    ensure => absent,
+  if $::openldap::server::remove_default_databases {
+    openldap::server::database { 'dc=my-domain,dc=com':
+      ensure => absent,
+    }
   }
 
   create_resources('openldap::server::database', $::openldap::server::databases)


### PR DESCRIPTION
When running slapd in proxy mode it's not possible to remove the default database, so this option makes it possible to do basic setup of the ldap server and client with this module and afterwards config the server as proxy manually (or with puppet).
