### PR TITLE
Allow complex access rule

### DIFF
--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -26,7 +26,7 @@ Puppet::Type.newtype(:openldap_access) do
   def self.title_patterns
     [
       [
-        /^(to\s+(\S+)\s+by\s+(.+)\s+on\s+(.+))$/,
+        /^(to\s+((?:(?:\S+)\s+){1,2})by\s+(.+)\s+on\s+(.+))$/,
         [
           [ :name, lambda{|x| x} ],
           [ :what, lambda{|x| x} ],


### PR DESCRIPTION
Only one attrbute "to" was allowed (dn, attrs) in access rules.
With this path we can now write access rule like this: 

```
to dn.subtree="ou=people,dc=example,dc=com" attrs=objectclass,uid,cn by dn="uid=nuxeo,ou=internal,dc=exmaple,dc=com" on dc=example,dc=com
```
