### PR TITLE
Allow to set rewrite overlay with a relay database

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,24 @@ openldap::server::schema { 'nis':
   require => Openldap::Server::Schema["inetorgperson"],
 }
 ```
+
+###Configuring Rewrite-overlay
+```puppet
+openldap::server::database { 'relay':
+  ensure  => present,
+  backend => 'relay',
+  suffix  => 'o=example',
+  relay   => 'dc=example,dc=com',
+}->
+
+openldap::server::overlay { "rwm on relay":
+  ensure  => present,
+  suffix  => 'relay',
+  overlay => 'rwm',
+  options => {
+    'olcRwmRewrite' => [
+      '{0}rwm-rewriteEngine "on"',
+      '{1}rwm-suffixmassage , "dc=example,dc=com"]',
+  },
+}
+```

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -197,39 +197,38 @@ Puppet::Type.
     t << "objectClass: olcDatabaseConfig\n"
     t << "objectClass: olc#{resource[:backend].to_s.capitalize}Config\n"
     t << "olcDatabase: #{resource[:backend]}\n"
-    if "#{resource[:backend]}" == "relay"
+
+    case "#{resource[:backend]}"
+    when "relay"
+      t << "olcRelay: #{resource[:relay]}\n" if !resource[:relay].empty?
       t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
-      t << "olcRelay: #{resource[:relay]}\n" if resource[:relay]
+    when "monitor"
+      # WRITE HERE FOR MONITOR ONLY
     else
-      if "#{resource[:backend]}" != "monitor"
-        t << "olcDbDirectory: #{resource[:directory]}\n" if resource[:directory]
-        t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
-        t << "olcDbIndex: objectClass eq\n" if !resource[:dboptions] or !resource[:dboptions]['index']
-      end
       t << "olcDbDirectory: #{resource[:directory]}\n" if resource[:directory]
       t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
       t << "olcDbIndex: objectClass eq\n" if !resource[:dboptions] or !resource[:dboptions]['index']
-      t << "olcRootDN: #{resource[:rootdn]}\n" if resource[:rootdn]
-      t << "olcRootPW: #{resource[:rootpw]}\n" if resource[:rootpw]
-      t << "olcReadOnly: #{resource[:readonly] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:readonly]
-      t << "olcSizeLimit: #{resource[:sizelimit]}\n" if resource[:sizelimit]
-      t << "olcTimeLimit: #{resource[:timelimit]}\n" if resource[:timelimit]
-      t << "olcUpdateref: #{resource[:updateref]}\n" if resource[:updateref]
-      if resource[:dboptions]
-        resource[:dboptions].each do |k, v|
-          case k
-          when 'dbnosync'
-            t << "olcDbNosync: #{v}\n"
-          when 'dbpagesize'
-            t << "olcDbPagesize: #{v}\n"
-          when 'dbconfig'
-            t << v.collect { |x| "olcDbConfig: #{x}" }.join("\n") + "\n"
+    end
+    t << "olcRootDN: #{resource[:rootdn]}\n" if resource[:rootdn]
+    t << "olcRootPW: #{resource[:rootpw]}\n" if resource[:rootpw]
+    t << "olcReadOnly: #{resource[:readonly] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:readonly]
+    t << "olcSizeLimit: #{resource[:sizelimit]}\n" if resource[:sizelimit]
+    t << "olcTimeLimit: #{resource[:timelimit]}\n" if resource[:timelimit]
+    t << "olcUpdateref: #{resource[:updateref]}\n" if resource[:updateref]
+    if resource[:dboptions]
+      resource[:dboptions].each do |k, v|
+        case k
+        when 'dbnosync'
+          t << "olcDbNosync: #{v}\n"
+        when 'dbpagesize'
+          t << "olcDbPagesize: #{v}\n"
+        when 'dbconfig'
+          t << v.collect { |x| "olcDbConfig: #{x}" }.join("\n") + "\n"
+        else
+          if v.is_a?(Array)
+            t << v.collect { |x| "olcDb#{k}: #{x}" }.join("\n") + "\n"
           else
-            if v.is_a?(Array)
-              t << v.collect { |x| "olcDb#{k}: #{x}" }.join("\n") + "\n"
-            else
-              t << "olcDb#{k}: #{v}\n"
-            end
+            t << "olcDb#{k}: #{v}\n"
           end
         end
       end

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -34,7 +34,7 @@ Puppet::Type.
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
-          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/).captures 
+          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/).captures
         when /^olcDbDirectory: /
           directory = line.split(' ')[1]
         when /^olcRootDN: /
@@ -197,13 +197,15 @@ Puppet::Type.
     t << "objectClass: olcDatabaseConfig\n"
     t << "objectClass: olc#{resource[:backend].to_s.capitalize}Config\n"
     t << "olcDatabase: #{resource[:backend]}\n"
-    case "#{resource[:backend]}"
-    when "relay"
+    if "#{resource[:backend]}" == "relay"
       t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
       t << "olcRelay: #{resource[:relay]}\n" if resource[:relay]
-    when "monitor"
-      # WRITE HERE FOR MONITOR BACKEND
     else
+      if "#{resource[:backend]}" != "monitor"
+        t << "olcDbDirectory: #{resource[:directory]}\n" if resource[:directory]
+        t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
+        t << "olcDbIndex: objectClass eq\n" if !resource[:dboptions] or !resource[:dboptions]['index']
+      end
       t << "olcDbDirectory: #{resource[:directory]}\n" if resource[:directory]
       t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
       t << "olcDbIndex: objectClass eq\n" if !resource[:dboptions] or !resource[:dboptions]['index']

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -115,6 +115,12 @@ Puppet::Type.
   def getDn(suffix)
     if suffix == 'cn=config'
       return 'olcDatabase={0}config,cn=config'
+    elsif suffix == 'relay'
+      slapcat("(olcDatabase=#{suffix})").split("\n").collect do |line|
+        if line =~ /^dn: /
+          return line.split(' ')[1]
+        end
+      end
     else
       slapcat("(olcSuffix=#{suffix})").split("\n").collect do |line|
         if line =~ /^dn: /
@@ -132,6 +138,8 @@ Puppet::Type.
       end
       if database == '{0}config'
         return 'cn=config'
+      elsif database =~ /\{\d+\}relay$/
+        return database # returns origin: {x}relay
       elsif line =~ /^olcSuffix: / and found
         return line.split(' ')[1]
       end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -9,6 +9,10 @@ Puppet::Type.newtype(:openldap_database) do
     desc "The default namevar."
   end
 
+  newparam(:relay) do
+    desc "The relay configuration."
+  end
+
   newparam(:target) do
   end
 
@@ -18,7 +22,7 @@ Puppet::Type.newtype(:openldap_database) do
 
   newproperty(:backend) do
     desc "The name of the backend."
-    newvalues('bdb', 'hdb', 'mdb', 'monitor', 'config')
+    newvalues('bdb', 'hdb', 'mdb', 'monitor', 'config', 'relay')
     defaultto do
       case Facter.value(:osfamily)
       when 'Debian'
@@ -47,7 +51,7 @@ Puppet::Type.newtype(:openldap_database) do
   newproperty(:directory) do
     desc "The directory where the BDB files containing this database and associated indexes live."
     defaultto do
-      if "#{@resource[:backend]}" != "monitor" and "#{@resource[:backend]}" != "config"
+      if "#{@resource[:backend]}" != "monitor" and "#{@resource[:backend]}" != "config" and "#{@resource[:backend]}" != "relay"
         '/var/lib/ldap'
       end
     end
@@ -117,7 +121,7 @@ Puppet::Type.newtype(:openldap_database) do
 
     newvalues(:true, :false)
     defaultto do
-      if "#{@resource[:backend]}" == "monitor" or "#{@resource[:backend]}" == "config"
+      if "#{@resource[:backend]}" == "monitor" or "#{@resource[:backend]}" == "config" or "#{@resource[:backend]}" == "relay"
         :false
       else
         :true

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -51,7 +51,7 @@ Puppet::Type.newtype(:openldap_database) do
   newproperty(:directory) do
     desc "The directory where the BDB files containing this database and associated indexes live."
     defaultto do
-      if "#{@resource[:backend]}" != "monitor" and "#{@resource[:backend]}" != "config" and "#{@resource[:backend]}" != "relay"
+      unless [ "monitor" , "config", "relay" ].include? "#{@resource[:backend]}"
         '/var/lib/ldap'
       end
     end
@@ -121,7 +121,7 @@ Puppet::Type.newtype(:openldap_database) do
 
     newvalues(:true, :false)
     defaultto do
-      if "#{@resource[:backend]}" == "monitor" or "#{@resource[:backend]}" == "config" or "#{@resource[:backend]}" == "relay"
+      if [ "monitor" , "config", "relay" ].include? "#{@resource[:backend]}"
         :false
       else
         :true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,9 +26,10 @@ class openldap::params {
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
       $server_service           = $::operatingsystemmajrelease ? {
-        '5' => 'ldap',
-        '6' => 'slapd',
-        '7' => 'slapd',
+        '5'     => 'ldap',
+        '6'     => 'slapd',
+        '7'     => 'slapd',
+        default => 'slapd',
       }
       $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,10 +26,9 @@ class openldap::params {
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
       $server_service           = $::operatingsystemmajrelease ? {
-        '5'     => 'ldap',
-        '6'     => 'slapd',
-        '7'     => 'slapd',
-        default => 'slapd',
+        '5' => 'ldap',
+        '6' => 'slapd',
+        '7' => 'slapd',
       }
       $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -3,6 +3,7 @@ define openldap::server::database(
   $ensure          = present,
   $directory       = undef,
   $suffix          = $title,
+  $relay           = undef,
   $backend         = undef,
   $rootdn          = undef,
   $rootpw          = undef,
@@ -60,6 +61,7 @@ define openldap::server::database(
   openldap_database { $title:
     ensure          => $ensure,
     suffix          => $suffix,
+    relay           => $relay,
     provider        => $::openldap::server::provider,
     target          => $::openldap::server::conffile,
     backend         => $backend,

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -29,6 +29,7 @@ define openldap::server::database(
   $manage_directory = $backend ? {
     'monitor' => undef,
     'config'  => undef,
+    'relay'   => undef,
     default   => $directory ? {
       undef   => '/var/lib/ldap',
       default => $directory,
@@ -48,7 +49,7 @@ define openldap::server::database(
     Openldap::Server::Database['dc=my-domain,dc=com'] -> Openldap::Server::Database[$title]
   }
 
-  if $ensure == present and $backend != 'monitor' and $backend != 'config' {
+  if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' {
     validate_absolute_path($manage_directory)
     file { $manage_directory:
       ensure => directory,


### PR DESCRIPTION
I found that I could set rwm overlay with a current version of the OpenLDAP module.
but I could not able to set the relay database at all.
so I modified the source codes to allow set rewrite overlay.
also I added a content how to set rewrite overlay on the README.md file.

I tested it on my dev environment for my company.

Please confirm the codes I changed
