### PR TITLE
feat: add security attribute to database resource

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -31,6 +31,7 @@ Puppet::Type.
       syncusesubentry = nil
       syncrepl = nil
       limits = []
+      security = {}
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
@@ -87,6 +88,11 @@ Puppet::Type.
         when /^olcLimits: /
           limit = line.match(/^olcLimits:\s+(\{\d+\})?(.+)$/).captures[1]
           limits << limit
+        when /^olcSecurity: /
+          line.split(': ')[1].split(' ').each do |variable|
+            values = variable.split('=')
+            security[values[0]] = values[1]
+          end
         end
       end
       if backend == 'monitor' and !suffix
@@ -113,7 +119,8 @@ Puppet::Type.
         :mirrormode      => mirrormode,
         :syncusesubentry => syncusesubentry,
         :syncrepl        => syncrepl,
-        :limits          => limits
+        :limits          => limits,
+        :security        => security
       )
     end
   end
@@ -237,6 +244,7 @@ Puppet::Type.
     t << "olcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:mirrormode]
     t << "olcSyncUseSubentry: #{resource[:syncusesubentry]}\n" if resource[:syncusesubentry]
     t << "#{resource[:limits].collect { |x| "olcLimits: #{x}" }.join("\n")}\n" if resource[:limits] and !resource[:limits].empty?
+    t << "#{resource[:security].collect { |k, v| "olcSecurity: #{k}=#{v}" }.join("\n")}\n" if resource[:security] and !resource[:security].empty?
     t << "olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break\n"
     t << "olcAccess: to attrs=userPassword\n"
     t << "  by self write\n"
@@ -327,6 +335,10 @@ Puppet::Type.
     @property_flush[:limits] = value
   end
 
+  def security=(value)
+    @property_flush[:security] = value
+  end
+
   def flush
     if not @property_flush.empty?
       t = Tempfile.new('openldap_database')
@@ -377,6 +389,7 @@ Puppet::Type.
       t << "replace: olcMirrorMode\nolcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:mirrormode]
       t << "replace: olcSyncUseSubentry\nolcSyncUseSubentry: #{resource[:syncusesubentry]}\n-\n" if @property_flush[:syncusesubentry]
       t << "replace: olcLimits\n#{@property_flush[:limits].collect { |x| "olcLimits: #{x}" }.join("\n")}\n-\n" if @property_flush[:limits]
+      t << "replace: olcSecurity\n#{@property_flush[:security].collect { |k, v| "olcSecurity: #{k}=#{v}" }.join("\n")}\n-\n" if @property_flush[:security]
       t.close
       Puppet.debug(IO.read t.path)
       begin

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -192,4 +192,19 @@ Puppet::Type.newtype(:openldap_database) do
       end
     end
   end
+
+  newproperty(:security) do
+    desc "The olcSecurity configuration."
+    correct_keys = ['transport', 'sasl', 'simple_bind', 'ssf', 'tls', 'update_sasl', 'update_ssf', 'update_tls', 'update_transport']
+    validate do |value|
+      value.each do |k, v|
+        if ! correct_keys.include? k
+            raise ArgumentError, "Invalid security key: '#{k}' for value '#{v}'\nSecurity key must be one of these value: #{correct_keys.join(', ')}\nSee olcSecurity in `man slapd-config`"
+        end
+        if ! (Float(v) rescue false)
+            raise ArgumentError, "Invalid security value: '#{v}' for key '#{k}'\nSecurity value must be a number\nSee olcSecurity in `man slapd-config`"
+        end
+      end
+    end
+  end
 end

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -20,6 +20,7 @@ define openldap::server::database(
   $mirrormode      = undef,
   $syncusesubentry = undef,
   $syncrepl        = undef,
+  $security        = undef,
 ) {
 
   if ! defined(Class['openldap::server']) {
@@ -80,6 +81,7 @@ define openldap::server::database(
     syncusesubentry => $syncusesubentry,
     syncrepl        => $syncrepl,
     limits          => $limits,
+    security        => $security,
   }
 
 }


### PR DESCRIPTION
Add `olcSecurity` feature to the `openldap::server::database` resource as a new `security` parameter.

From slapd-config manual:

 > olcSecurity: \<factors\>
 >
 >  Specify  a set of security strength factors (separated by white space) to require (see olcSaslSecprops's minssf option for a description of security strength factors).  The directive may be specified globally and/or per-database.  ssf=\<n\> specifies the overall security strength factor.  transport=\<n\> specifies the transport  security  strength factor.   tls=\<n\> specifies the TLS security strength factor.  sasl=\<n\> specifies the SASL security strength factor.  update_ssf=\<n\> specifies the overall security strength factor to require for directory updates.  update_transport=\<n\> specifies the transport security strength factor to require for directory updates.  update_tls=\<n\>  specifies the  TLS  security  strength  factor  to  require  for  directory  updates.   update_sasl=\<n\>  specifies the SASL security strength factor to require for directory updates. simple_bind=\<n\> specifies the security strength factor required for simple username/password authentication.  Note that the transport factor is measure of security provided by the underlying transport, e.g. ldapi:// (and eventually IPSEC).  It is not normally used.