### PR TITLE
Support SASL and GSSAPI options in ldap.conf

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -35,6 +35,13 @@ class openldap::client(
   $tls_checkpeer        = undef,
   $tls_reqcert          = undef,
 
+  # SASL Options
+  $sasl_mech            = undef,
+  $sasl_realm           = undef,
+  $sasl_authcid         = undef,
+  $sasl_secprops        = undef,
+  $sasl_nocanon         = undef,
+
   # SUDO Options
   $sudoers_base         = undef,
 ) inherits ::openldap::params {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -42,6 +42,11 @@ class openldap::client(
   $sasl_secprops        = undef,
   $sasl_nocanon         = undef,
 
+  # GSSAPI Options
+  $gssapi_sign                   = undef,
+  $gssapi_encrypt                = undef,
+  $gssapi_allow_remote_principal = undef,
+
   # SUDO Options
   $sudoers_base         = undef,
 ) inherits ::openldap::params {

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -106,6 +106,30 @@ class openldap::client::config {
     undef   => undef,
     default => "set TLS_REQCERT ${::openldap::client::tls_reqcert}",
   }
+  $sasl_mech = $::openldap::client::sasl_mech ? {
+    undef   => undef,
+    default => "set SASL_MECH ${::openldap::client::sasl_mech}",
+  }
+  $sasl_realm = $::openldap::client::sasl_realm ? {
+    undef   => undef,
+    default => "set SASL_REALM ${::openldap::client::sasl_realm}",
+  }
+  $sasl_authcid = $::openldap::client::sasl_authcid ? {
+    undef   => undef,
+    default => "set SASL_AUTHCID ${::openldap::client::sasl_authcid}",
+  }
+  $_sasl_secprops = $::openldap::client::sasl_secprops ? {
+    undef   => undef,
+    default => join(flatten([$::openldap::client::sasl_secprops]), ','),
+  }
+  $sasl_secprops = $_sasl_secprops ? {
+    undef   => undef,
+    default => "set SASL_SECPROPS ${_sasl_secprops}",
+  }
+  $sasl_nocanon = $::openldap::client::sasl_nocanon ? {
+    undef   => undef,
+    default => "set SASL_NOCANON ${::openldap::client::sasl_nocanon}",
+  }
   $sudoers_base = $::openldap::client::sudoers_base ? {
     undef   => undef,
     default => "set SUDOERS_BASE ${::openldap::client::sudoers_base}",
@@ -135,6 +159,11 @@ class openldap::client::config {
     $tls_cacert,
     $tls_cacertdir,
     $tls_reqcert,
+    $sasl_mech,
+    $sasl_realm,
+    $sasl_authcid,
+    $sasl_secprops,
+    $sasl_nocanon,
     $sudoers_base,
   ])
   augeas { 'ldap.conf':

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -130,6 +130,18 @@ class openldap::client::config {
     undef   => undef,
     default => "set SASL_NOCANON ${::openldap::client::sasl_nocanon}",
   }
+  $gssapi_sign = $::openldap::client::gssapi_sign ? {
+    undef   => undef,
+    default => "set GSSAPI_SIGN ${::openldap::client::gssapi_sign}",
+  }
+  $gssapi_encrypt = $::openldap::client::gssapi_encrypt ? {
+    undef   => undef,
+    default => "set GSSAPI_ENCRYPT ${::openldap::client::gssapi_encrypt}",
+  }
+  $gssapi_allow_remote_principal = $::openldap::client::gssapi_allow_remote_principal ? {
+    undef   => undef,
+    default => "set GSSAPI_ALLOW_REMOTE_PRINCIPAL ${::openldap::client::gssapi_allow_remote_principal}",
+  }
   $sudoers_base = $::openldap::client::sudoers_base ? {
     undef   => undef,
     default => "set SUDOERS_BASE ${::openldap::client::sudoers_base}",
@@ -164,6 +176,9 @@ class openldap::client::config {
     $sasl_authcid,
     $sasl_secprops,
     $sasl_nocanon,
+    $gssapi_sign,
+    $gssapi_encrypt,
+    $gssapi_allow_remote_principal,
     $sudoers_base,
   ])
   augeas { 'ldap.conf':

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -633,6 +633,44 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with sasl options set' do
+        let :pre_condition do
+          "class {'openldap::client':
+                   sasl_mech => 'gssapi',
+                   sasl_realm => 'TEST.REALM',
+                   sasl_authcid => 'dn:uid=test,cn=mech,cn=authzid',
+                   sasl_secprops => ['noplain','noactive'],
+                   sasl_nocanon => true,
+           }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/ldap/ldap.conf',
+            :changes => [ 'set SASL_MECH gssapi',
+                          'set SASL_REALM TEST.REALM',
+                          'set SASL_AUTHCID dn:uid=test,cn=mech,cn=authzid',
+                          'set SASL_SECPROPS noplain,noactive',
+                          'set SASL_NOCANON true'],
+          })
+          }
+        when 'RedHat'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/openldap/ldap.conf',
+            :changes => [ 'set SASL_MECH gssapi',
+                          'set SASL_REALM TEST.REALM',
+                          'set SASL_AUTHCID dn:uid=test,cn=mech,cn=authzid',
+                          'set SASL_SECPROPS noplain,noactive',
+                          'set SASL_NOCANON true'],
+          })
+          }
+        end
+      end
+
       context 'with sudoers_base set' do
         let :pre_condition do
           "class {'openldap::client': sudoers_base => 'ou=sudoers,dc=example,dc=com', }"

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -671,6 +671,38 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with gssapi options set' do
+        let :pre_condition do
+          "class {'openldap::client':
+                   gssapi_sign => false,
+                   gssapi_encrypt => true,
+                   gssapi_allow_remote_principal => 'on'
+           }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/ldap/ldap.conf',
+            :changes => [ 'set GSSAPI_SIGN false',
+                          'set GSSAPI_ENCRYPT true',
+                          'set GSSAPI_ALLOW_REMOTE_PRINCIPAL on'],
+          })
+          }
+        when 'RedHat'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/openldap/ldap.conf',
+            :changes => [ 'set GSSAPI_SIGN false',
+                          'set GSSAPI_ENCRYPT true',
+                          'set GSSAPI_ALLOW_REMOTE_PRINCIPAL on'],
+          })
+          }
+        end
+      end
+
       context 'with sudoers_base set' do
         let :pre_condition do
           "class {'openldap::client': sudoers_base => 'ou=sudoers,dc=example,dc=com', }"


### PR DESCRIPTION
Based on https://linux.die.net/man/5/ldap.conf
