### PR TITLE
support Amazon linux 2015+ and make version checks more flexible

### DIFF
--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -28,7 +28,7 @@ Puppet::Type.newtype(:openldap_database) do
       when 'Debian'
         case Facter.value(:operatingsystem)
         when 'Debian'
-          if Facter.value(:operatingsystemmajrelease).to_i < 8
+          if Facter.value(:operatingsystemmajrelease).to_i <= 7
             'hdb'
           else
             'mdb'
@@ -39,7 +39,7 @@ Puppet::Type.newtype(:openldap_database) do
           'hdb'
         end
       when 'RedHat'
-        if Facter.value(:operatingsystemmajrelease).to_i < 7
+        if Facter.value(:operatingsystemmajrelease).to_i <= 6
           'bdb'
         else
           'hdb'

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -28,7 +28,7 @@ Puppet::Type.newtype(:openldap_database) do
       when 'Debian'
         case Facter.value(:operatingsystem)
         when 'Debian'
-          if Facter.value(:operatingsystemmajrelease).to_i <= 7
+          if Facter.value(:operatingsystemmajrelease).to_i < 8
             'hdb'
           else
             'mdb'
@@ -39,7 +39,7 @@ Puppet::Type.newtype(:openldap_database) do
           'hdb'
         end
       when 'RedHat'
-        if Facter.value(:operatingsystemmajrelease).to_i <= 6
+        if Facter.value(:operatingsystemmajrelease).to_i < 7
           'bdb'
         else
           'hdb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '5' {
+      if $::operatingsystem == 'Debian' and ${::operatingsystemmajrelease}.to_i <= 5 {
         $server_service_hasstatus = false
       } else {
         $server_service_hasstatus = true
@@ -25,10 +25,9 @@ class openldap::params {
       $server_group             = 'ldap'
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
-      $server_service           = $::operatingsystemmajrelease ? {
-        '5' => 'ldap',
-        '6' => 'slapd',
-        '7' => 'slapd',
+      $server_service           = ${::operatingsystemmajrelease}.to_i ? {
+        5 => 'ldap',
+        default => 'slapd',
       }
       $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease).to_i <= 5 {
+      if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) <= '5' {
         $server_service_hasstatus = false
       } else {
         $server_service_hasstatus = true
@@ -26,8 +26,8 @@ class openldap::params {
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
       # RHEL6+ and Amazon Linux use 'slapd'
-      $server_service           = Facter.value(:operatingsystemmajrelease).to_i ? {
-        5 => 'ldap',
+      $server_service           = Facter.value(:operatingsystemmajrelease) ? {
+        '5' => 'ldap',
         default => 'slapd',
       }
       $server_service_hasstatus = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) <= '5' {
+      if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '5' {
         $server_service_hasstatus = false
       } else {
         $server_service_hasstatus = true
@@ -25,10 +25,10 @@ class openldap::params {
       $server_group             = 'ldap'
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
-      # RHEL6+ and Amazon Linux use 'slapd'
-      $server_service           = Facter.value(:operatingsystemmajrelease) ? {
+      $server_service           = $::operatingsystemmajrelease ? {
         '5' => 'ldap',
-        default => 'slapd',
+        '6' => 'slapd',
+        '7' => 'slapd',
       }
       $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if $::operatingsystem == 'Debian' and ${::operatingsystemmajrelease}.to_i <= 5 {
+      if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease <= '5' {
         $server_service_hasstatus = false
       } else {
         $server_service_hasstatus = true
@@ -25,8 +25,8 @@ class openldap::params {
       $server_group             = 'ldap'
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
-      $server_service           = ${::operatingsystemmajrelease}.to_i ? {
-        5 => 'ldap',
+      $server_service           = $::operatingsystemmajrelease ? {
+        '5' => 'ldap',
         default => 'slapd',
       }
       $server_service_hasstatus = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '5' {
+      if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) <= '5' {
         $server_service_hasstatus = false
       } else {
         $server_service_hasstatus = true
@@ -25,10 +25,10 @@ class openldap::params {
       $server_group             = 'ldap'
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
-      $server_service           = $::operatingsystemmajrelease ? {
+      # RHEL6+ and Amazon Linux use 'slapd'
+      $server_service           = Facter.value(:operatingsystemmajrelease) ? {
         '5' => 'ldap',
-        '6' => 'slapd',
-        '7' => 'slapd',
+        default => 'slapd',
       }
       $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) <= '5' {
+      if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease).to_i <= 5 {
         $server_service_hasstatus = false
       } else {
         $server_service_hasstatus = true
@@ -26,8 +26,8 @@ class openldap::params {
       $server_owner             = 'ldap'
       $server_package           = 'openldap-servers'
       # RHEL6+ and Amazon Linux use 'slapd'
-      $server_service           = Facter.value(:operatingsystemmajrelease) ? {
-        '5' => 'ldap',
+      $server_service           = Facter.value(:operatingsystemmajrelease).to_i ? {
+        5 => 'ldap',
         default => 'slapd',
       }
       $server_service_hasstatus = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease <= '5' {
+      if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '5') <= 0 {
         $server_service_hasstatus = false
       } else {
         $server_service_hasstatus = true

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,7 +29,7 @@ class openldap::server::config {
       }
     }
     'RedHat': {
-      if versioncmp($::operatingsystemmajrelease, '6') <= 0 {
+      if ${::operatingsystemmajrelease}.to_i <= 6 {
         $ldap = empty($::openldap::server::ldap_ifs) ? {
           false => 'yes',
           true  => 'no',

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,7 +29,7 @@ class openldap::server::config {
       }
     }
     'RedHat': {
-      if Facter.value(:operatingsystemmajrelease).to_i <= 6 {
+      if versioncmp($::operatingsystemmajrelease, '6') <= 0 {
         $ldap = empty($::openldap::server::ldap_ifs) ? {
           false => 'yes',
           true  => 'no',

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,7 +29,7 @@ class openldap::server::config {
       }
     }
     'RedHat': {
-      if ${::operatingsystemmajrelease}.to_i <= 6 {
+      if $::operatingsystemmajrelease <= '6' {
         $ldap = empty($::openldap::server::ldap_ifs) ? {
           false => 'yes',
           true  => 'no',

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,7 +29,7 @@ class openldap::server::config {
       }
     }
     'RedHat': {
-      if $::operatingsystemmajrelease <= '6' {
+      if versioncmp($::operatingsystemmajrelease, '6') <= 0 {
         $ldap = empty($::openldap::server::ldap_ifs) ? {
           false => 'yes',
           true  => 'no',

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,7 +29,7 @@ class openldap::server::config {
       }
     }
     'RedHat': {
-      if versioncmp($::operatingsystemmajrelease, '6') <= 0 {
+      if Facter.value(:operatingsystemmajrelease).to_i <= 6 {
         $ldap = empty($::openldap::server::ldap_ifs) ? {
           false => 'yes',
           true  => 'no',

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease).to_i >= 8 {
+  if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) >= '8' {
     # Puppet4 fallback to init provider which does not support enableable
     $provider = 'debian'
   } else {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) >= '8' {
+  if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '8' {
     # Puppet4 fallback to init provider which does not support enableable
     $provider = 'debian'
   } else {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease >= '8' {
+  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0 {
     # Puppet4 fallback to init provider which does not support enableable
     $provider = 'debian'
   } else {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if $::operatingsystem == 'Debian' and ${::operatingsystemmajrelease}.to_i >= 8 {
+  if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease >= '8' {
     # Puppet4 fallback to init provider which does not support enableable
     $provider = 'debian'
   } else {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '8' {
+  if $::operatingsystem == 'Debian' and ${::operatingsystemmajrelease}.to_i >= 8 {
     # Puppet4 fallback to init provider which does not support enableable
     $provider = 'debian'
   } else {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) >= '8' {
+  if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease).to_i >= 8 {
     # Puppet4 fallback to init provider which does not support enableable
     $provider = 'debian'
   } else {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,7 +10,7 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '8' {
+  if Facter.value(:operatingsystem) == 'Debian' and Facter.value(:operatingsystemmajrelease) >= '8' {
     # Puppet4 fallback to init provider which does not support enableable
     $provider = 'debian'
   } else {

--- a/metadata.json
+++ b/metadata.json
@@ -52,6 +52,13 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2015",
+        "2016"
+      ]
     }
   ],
   "puppet_version": [


### PR DESCRIPTION
Amazon Linux uses 4-digit year as it's 'operatingsystemmajrelease' value and does not have a compat equivalent and so it is entirely possible that a recent (eg. 2015) AMI is RHEL5.11 based and will get lumped into RHEL6+ behavior and break. For that situation recommend overriding facter with:     FACTER_operatingsystemmajrelease=5 puppet ...

Would have preferred to use "$facts['os']['release']['major']" style but that appears to be problematic depending on Puppet release.

ps. please forgive previous 'git pull' cock-up - juxtaposing library/ruby code capabilities with Puppet manifest directives was a silly mistake.