### PR TITLE
Make NETWORK_TIMEOUT a configurable option.

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -10,6 +10,7 @@ class openldap::client(
   $binddn               = undef,
   $bindpw               = undef,
   $ldap_version         = undef,
+  $network_timeout      = undef,
   $scope                = undef,
   $ssl                  = undef,
   $suffix               = undef,

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -24,6 +24,10 @@ class openldap::client::config {
     undef   => undef,
     default => "set LDAP_VERSION ${::openldap::client::ldap_version}",
   }
+  $network_timeout = $::openldap::client::network_timeout ? {
+    undef   => undef,
+    default => "set NETWORK_TIMEOUT ${::openldap::client::network_timeout}",
+  }
   $scope = $::openldap::client::scope ? {
     undef   => undef,
     default => "set SCOPE ${::openldap::client::scope}",
@@ -117,6 +121,7 @@ class openldap::client::config {
     $binddn,
     $bindpw,
     $ldap_version,
+    $network_timeout,
     $scope,
     $ssl,
     $suffix,

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -162,6 +162,30 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with network_timeout set' do
+        let :pre_condition do
+          "class {'openldap::client': network_timeout => '1', }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/ldap/ldap.conf',
+            :changes => [ 'set NETWORK_TIMEOUT 1' ],
+          })
+          }
+        when 'RedHat'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/openldap/ldap.conf',
+            :changes => [ 'set NETWORK_TIMEOUT 1' ],
+          })
+          }
+        end
+      end
+
       context 'with scope set' do
         let :pre_condition do
           "class {'openldap::client': scope => 'one', }"


### PR DESCRIPTION
From the LDAP.conf(5) manual:

Specifies the timeout (in seconds) after which the poll(2)/select(2)
following a connect(2) returns in case of no activity.