### PR TITLE
Use contain instead of include

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -6,7 +6,7 @@ class openldap::server::install {
   }
 
   if $::openldap::server::provider == 'olc' {
-    include ::openldap::utils
+    contain ::openldap::utils
   }
 
   if $::osfamily == 'Debian' {


### PR DESCRIPTION
With include the openldap::utils class 'floats' and therefore dependencies may not be respected, breaking - for example - TLS installations