### PR TITLE
Fix ordering so that Openldap::Server::Globalconf resources will come after the openldap service

### DIFF
--- a/manifests/server/globalconf.pp
+++ b/manifests/server/globalconf.pp
@@ -10,7 +10,12 @@ define openldap::server::globalconf(
 
   if $::openldap::server::provider == 'augeas' {
     Openldap::Server::Globalconf[$title] ~> Class['openldap::server::service']
+  } else {
+    Class['openldap::server::service'] ->
+    Openldap::Server::Globalconf[$title] ->
+    Class['openldap::server']
   }
+
   openldap_global_conf { $name:
     ensure   => $ensure,
     provider => $::openldap::server::provider,


### PR DESCRIPTION
Without this change, using openldap::server::globalconf results in a fresh system trying to set global config items before the slapd service is running.