### PR TITLE
Change updateref order

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -352,7 +352,6 @@ Puppet::Type.
       t << "replace: olcReadOnly\nolcReadOnly: #{resource[:readonly] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:readonly]
       t << "replace: olcSizeLimit\nolcSizeLimit: #{resource[:sizelimit]}\n-\n" if @property_flush[:sizelimit]
       t << "replace: olcTimeLimit\nolcTimeLimit: #{resource[:timelimit]}\n-\n" if @property_flush[:timelimit]
-      t << "replace: olcUpdateref\nolcUpdateref: #{resource[:updateref]}\n-\n" if @property_flush[:updateref]
       if @property_flush[:dboptions]
         if "#{resource[:synctype]}" == "inclusive" and !@property_hash[:dboptions].empty?
           @property_hash[:dboptions].keys.each do |k|
@@ -386,6 +385,7 @@ Puppet::Type.
         end
       end
       t << "replace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
+      t << "replace: olcUpdateref\nolcUpdateref: #{resource[:updateref]}\n-\n" if @property_flush[:updateref]
       t << "replace: olcMirrorMode\nolcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:mirrormode]
       t << "replace: olcSyncUseSubentry\nolcSyncUseSubentry: #{resource[:syncusesubentry]}\n-\n" if @property_flush[:syncusesubentry]
       t << "replace: olcLimits\n#{@property_flush[:limits].collect { |x| "olcLimits: #{x}" }.join("\n")}\n-\n" if @property_flush[:limits]


### PR DESCRIPTION
When creating a mirrored configuration and using `syncrepl` and `updateref` params, the generated LDIF processed by ldapmodify  has the `syncrepl` change after the `updateref`change. That provokes the following error:

 `<olcUpdateRef> must appear after syncrepl or updatedn`

This just changes the order which seems to solve the problem.

Tested with:
```
#slapd -V
@(#) $OpenLDAP: slapd  (Jan 16 2016 23:00:08) $
       	root@chimera:/tmp/buildd/openldap-2.4.40+dfsg/debian/build/servers/slapd
```