### PR TITLE
Allow openldap::client config values to have 'absent' value remove the entry from ldap.conf

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,118 +1,144 @@
 # See README.md for details.
 class openldap::client::config {
   $base = $::openldap::client::base ? {
-    undef   => undef,
-    default => "set BASE ${::openldap::client::base}",
+    undef    => undef,
+    'absent' => 'rm BASE',
+    default  => "set BASE ${::openldap::client::base}",
   }
   $bind_policy = $::openldap::client::bind_policy ? {
-    undef   => undef,
-    default => "set BIND_POLICY ${::openldap::client::bind_policy}",
+    undef    => undef,
+    'absent' => 'rm BIND_POLICY',
+    default  => "set BIND_POLICY ${::openldap::client::bind_policy}",
   }
   $bind_timelimit = $::openldap::client::bind_timelimit ? {
-    undef   => undef,
-    default => "set BIND_TIMELIMIT ${::openldap::client::bind_timelimit}",
+    undef    => undef,
+    'absent' => 'rm BIND_TIMELIMIT',
+    default  => "set BIND_TIMELIMIT ${::openldap::client::bind_timelimit}",
   }
   $binddn = $::openldap::client::binddn ? {
-    undef   => undef,
-    default => "set BINDDN ${::openldap::client::binddn}",
+    undef    => undef,
+    'absent' => 'rm BINDDN',
+    default  => "set BINDDN ${::openldap::client::binddn}",
   }
   $bindpw = $::openldap::client::bindpw ? {
-    undef   => undef,
-    default => "set BINDPW ${::openldap::client::bindpw}",
+    undef    => undef,
+    'absent' => 'rm BINDPW',
+    default  => "set BINDPW ${::openldap::client::bindpw}",
   }
   $ldap_version = $::openldap::client::ldap_version ? {
-    undef   => undef,
-    default => "set LDAP_VERSION ${::openldap::client::ldap_version}",
+    undef    => undef,
+    'absent' => 'rm LDAP_VERSION',
+    default  => "set LDAP_VERSION ${::openldap::client::ldap_version}",
   }
   $network_timeout = $::openldap::client::network_timeout ? {
-    undef   => undef,
-    default => "set NETWORK_TIMEOUT ${::openldap::client::network_timeout}",
+    undef    => undef,
+    'absent' => 'rm NETWORK_TIMEOUT',
+    default  => "set NETWORK_TIMEOUT ${::openldap::client::network_timeout}",
   }
   $scope = $::openldap::client::scope ? {
-    undef   => undef,
-    default => "set SCOPE ${::openldap::client::scope}",
+    undef    => undef,
+    'absent' => 'rm SCOPE',
+    default  => "set SCOPE ${::openldap::client::scope}",
   }
   $ssl = $::openldap::client::ssl ? {
-    undef   => undef,
-    default => "set SSL ${::openldap::client::ssl}",
+    undef    => undef,
+    'absent' => 'rm SSL',
+    default  => "set SSL ${::openldap::client::ssl}",
   }
   $suffix = $::openldap::client::suffix ? {
-    undef   => undef,
-    default => "set SUFFIX ${::openldap::client::suffix}",
+    undef    => undef,
+    'absent' => 'rm SUFFIX',
+    default  => "set SUFFIX ${::openldap::client::suffix}",
   }
   $timelimit = $::openldap::client::timelimit ? {
-    undef   => undef,
-    default => "set TIMELIMIT ${::openldap::client::timelimit}",
+    undef    => undef,
+    'absent' => 'rm TIMELIMIT',
+    default  => "set TIMELIMIT ${::openldap::client::timelimit}",
   }
   $timeout = $::openldap::client::timeout ? {
-    undef   => undef,
-    default => "set TIMEOUT ${::openldap::client::timeout}",
+    undef    => undef,
+    'absent' => 'rm TIMEOUT',
+    default  => "set TIMEOUT ${::openldap::client::timeout}",
   }
   $_uri = $::openldap::client::uri ? {
     undef   => undef,
     default => join(flatten([$::openldap::client::uri]), ' '),
   }
   $uri = $_uri ? {
-    undef   => undef,
-    default => "set URI '${_uri}'",
+    undef    => undef,
+    'absent' => 'rm URI',
+    default  => "set URI '${_uri}'",
   }
   $nss_base_group = $::openldap::client::nss_base_group ? {
-    undef   => undef,
-    default => "set NSS_BASE_GROUP ${::openldap::client::nss_base_group}",
+    undef    => undef,
+    'absent' => 'rm NSS_BASE_GROUP',
+    default  => "set NSS_BASE_GROUP ${::openldap::client::nss_base_group}",
   }
   $nss_base_hosts = $::openldap::client::nss_base_hosts ? {
-    undef   => undef,
-    default => "set NSS_BASE_HOSTS ${::openldap::client::nss_base_hosts}",
+    undef    => undef,
+    'absent' => 'rm NSS_BASE_HOSTS',
+    default  => "set NSS_BASE_HOSTS ${::openldap::client::nss_base_hosts}",
   }
   $nss_base_passwd = $::openldap::client::nss_base_passwd ? {
-    undef   => undef,
-    default => "set NSS_BASE_PASSWD ${::openldap::client::nss_base_passwd}",
+    undef    => undef,
+    'absent' => 'rm NSS_BASE_PASSWD',
+    default  => "set NSS_BASE_PASSWD ${::openldap::client::nss_base_passwd}",
   }
   $nss_base_shadow = $::openldap::client::nss_base_shadow ? {
-    undef   => undef,
-    default => "set NSS_BASE_SHADOW ${::openldap::client::nss_base_shadow}",
+    undef    => undef,
+    'absent' => 'rm NSS_BASE_SHADOW',
+    default  => "set NSS_BASE_SHADOW ${::openldap::client::nss_base_shadow}",
   }
   $pam_filter = $::openldap::client::pam_filter ? {
-    undef   => undef,
-    default => "set PAM_FILTER ${::openldap::client::pam_filter}",
+    undef    => undef,
+    'absent' => 'rm PAM_FILTER',
+    default  => "set PAM_FILTER ${::openldap::client::pam_filter}",
   }
   $pam_login_attribute = $::openldap::client::pam_login_attribute ? {
-    undef   => undef,
-    default => "set PAM_LOGIN_ATTRIBUTE ${::openldap::client::pam_login_attribute}",
+    undef    => undef,
+    'absent' => 'rm PAM_LOGIN_ATTRIBUTE',
+    default  => "set PAM_LOGIN_ATTRIBUTE ${::openldap::client::pam_login_attribute}",
   }
   $pam_member_attribute = $::openldap::client::pam_member_attribute ? {
-    undef   => undef,
-    default => "set PAM_MEMBER_ATTRIBUTE ${::openldap::client::pam_member_attribute}",
+    undef    => undef,
+    'absent' => 'rm PAM_MEMBER_ATTRIBUTE',
+    default  => "set PAM_MEMBER_ATTRIBUTE ${::openldap::client::pam_member_attribute}",
   }
   $pam_password = $::openldap::client::pam_password ? {
-    undef   => undef,
-    default => "set PAM_PASSWORD ${::openldap::client::pam_password}",
+    undef    => undef,
+    'absent' => 'rm PAM_PASSWORD',
+    default  => "set PAM_PASSWORD ${::openldap::client::pam_password}",
   }
   $tls_checkpeer = $::openldap::client::tls_checkpeer ? {
-    undef   => undef,
-    default => "set TLS_CHECKPEER ${::openldap::client::tls_checkpeer}",
+    undef    => undef,
+    'absent' => 'rm TLS_CHECKPEER',
+    default  => "set TLS_CHECKPEER ${::openldap::client::tls_checkpeer}",
   }
   if $::openldap::client::tls_cacert != undef {
     validate_absolute_path($::openldap::client::tls_cacert)
   }
   $tls_cacert = $::openldap::client::tls_cacert ? {
-    undef   => undef,
-    default => "set TLS_CACERT ${::openldap::client::tls_cacert}",
+    undef    => undef,
+    'absent' => 'rm TLS_CACERT',
+    default  => "set TLS_CACERT ${::openldap::client::tls_cacert}",
   }
   if $::openldap::client::tls_cacertdir != undef {
     validate_absolute_path($::openldap::client::tls_cacertdir)
   }
   $tls_cacertdir = $::openldap::client::tls_cacertdir ? {
-    undef   => undef,
-    default => "set TLS_CACERTDIR ${::openldap::client::tls_cacertdir}",
+    undef    => undef,
+    'absent' => 'rm TLS_CACERTDIR',
+    default  => "set TLS_CACERTDIR ${::openldap::client::tls_cacertdir}",
   }
   $tls_reqcert = $::openldap::client::tls_reqcert ? {
-    undef   => undef,
-    default => "set TLS_REQCERT ${::openldap::client::tls_reqcert}",
+    undef    => undef,
+    'absent' => 'rm TLS_REQCERT',
+    default  => "set TLS_REQCERT ${::openldap::client::tls_reqcert}",
   }
   $sudoers_base = $::openldap::client::sudoers_base ? {
-    undef   => undef,
-    default => "set SUDOERS_BASE ${::openldap::client::sudoers_base}",
+    undef    => undef,
+    'absent' => 'rm SUDOERS_BASE',
+    default  => "set SUDOERS_BASE ${::openldap::client::sudoers_base}",
   }
   $changes = delete_undef_values([
     $base,

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -42,6 +42,30 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with base set to absent' do
+        let :pre_condition do
+          "class {'openldap::client': base => 'absent', }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/ldap/ldap.conf',
+            :changes => [ 'rm BASE' ],
+          })
+          }
+        when 'RedHat'
+          it { is_expected.to contain_augeas('ldap.conf').with({
+            :incl    => '/etc/openldap/ldap.conf',
+            :changes => [ 'rm BASE' ],
+          })
+          }
+        end
+      end
+
       context 'with bind_policy set' do
         let :pre_condition do
           "class {'openldap::client': bind_policy => 'soft', }"


### PR DESCRIPTION
I can update unit tests to cover all cases if this type of change would be merged.