### PR TITLE
Ensure that the password is hashed on db creation.

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -202,6 +202,12 @@ Puppet::Type.
   end
 
   def create
+    if resource[:rootpw] && resource[:rootpw] !~ /^\{(CRYPT|MD5|SMD5|SSHA|SHA(256|384|512)?)\}.+/
+      require 'securerandom'
+      salt = SecureRandom.random_bytes(4)
+      @resource[:rootpw] = "{SSHA}" + Base64.encode64("#{Digest::SHA1.digest("#{resource[:rootpw]}#{salt}")}#{salt}").chomp
+    end
+
     t = Tempfile.new('openldap_database')
     t << "dn: olcDatabase=#{resource[:backend]},cn=config\n"
     t << "changetype: add\n"


### PR DESCRIPTION
This code is taken from the `openldap_database` type. The `rootpw` property has logic to hash the password, if it isn't already hashed, and ensure that the database matches. However, when creating the database resource for the first time that code isn't executed and instead create is called on the provider. By duplicating the logic here we can ensure that the password is correctly hashed when the database is created.

This fixes #101 where the password is added unhashed during the first run but fixed on the next Puppet run when the logic in the type can take effect.

Minor niggle: duplicating code isn't ideal.