### PR TITLE
Set sensible default for dbindex attribute

### DIFF
--- a/manifests/server/dbindex.pp
+++ b/manifests/server/dbindex.pp
@@ -2,7 +2,7 @@
 define openldap::server::dbindex(
   $ensure    = undef,
   $suffix    = undef,
-  $attribute = $title,
+  $attribute = $name,
   $indices   = undef,
 ) {
 

--- a/manifests/server/dbindex.pp
+++ b/manifests/server/dbindex.pp
@@ -2,7 +2,7 @@
 define openldap::server::dbindex(
   $ensure    = undef,
   $suffix    = undef,
-  $attribute = undef,
+  $attribute = $title,
   $indices   = undef,
 ) {
 


### PR DESCRIPTION
This change makes it much easier to set several indexes in a batch, as in

    Openldap::Server::Dbindex {
      suffix => $basedn,
    }
    openldap::server::dbindex {
      ['assignedRole','cn','mail','mailAlias','objectClass','uid']:
        indices   => 'eq';
      ['member','uniqueMember']:
        indices   => 'pres,eq';
    }