### PR TITLE
Rewrite openldap_password to use native Ruby

### DIFF
--- a/lib/puppet/parser/functions/openldap_password.rb
+++ b/lib/puppet/parser/functions/openldap_password.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module Puppet::Parser::Functions
   newfunction(:openldap_password, :type => :rvalue, :doc => <<-EOS
       Returns the openldap password hash from the clear text password.
@@ -7,10 +9,29 @@ module Puppet::Parser::Functions
     raise(Puppet::ParseError, "openldap_password(): Wrong number of arguments given") if args.size < 1 or args.size > 2
 
     secret = args[0]
-    command = ['slappasswd', '-s', secret]
-    scheme = args[1] if args[1]
-    command << ['-h', scheme] if scheme
+    scheme = args[1] || '{SSHA}'
 
-    Puppet::Util::Execution.execute(command.flatten).strip
+    Puppet::Parser::Functions.function('fqdn_rand_string')
+
+    case scheme[/([A-Z,0-9]+)/, 1]
+    when 'CRYPT'
+      salt = function_fqdn_rand_string([2])
+      password = '{CRYPT}' + secret.crypt(salt)
+    when 'MD5'
+      password = '{MD5}' + Digest::MD5.hexdigest(secret)
+    when 'SMD5'
+      salt = function_fqdn_rand_string([8])
+      md5_hash_with_salt = "#{Digest::MD5.digest(secret + salt)}#{salt}"
+      password = '{SMD5}' + [md5_hash_with_salt].pack('m').gsub("\n", '')
+    when 'SSHA'
+      salt = function_fqdn_rand_string([8])
+      password = '{SSHA}' + Base64.encode64("#{Digest::SHA1.digest(secret + salt)}#{salt}").chomp
+    when 'SHA'
+      password = '{SHA}' + Digest::SHA1.hexdigest(secret)
+    else
+      raise(Puppet::ParseError, "openldap_password(): Unrecognized scheme #{scheme}")
+    end
+
+    password
   end
 end

--- a/spec/unit/puppet/parser/functions/openldap_password_spec.rb
+++ b/spec/unit/puppet/parser/functions/openldap_password_spec.rb
@@ -16,20 +16,30 @@ describe Puppet::Parser::Functions.function(:openldap_password) do
   end
 
   context 'when given only a secret' do
-    it 'should execute slappasswd on it' do
-      Puppet::Util::Execution.stubs(:execute).with([
-        'slappasswd', '-s', 'foo'
-      ]).returns("{SSHA}kKSBVuPOwlHp5HfcR3LBKyB7smTnbq9Y\n")
-      expect(scope.function_openldap_password(['foo'])).to eq('{SSHA}kKSBVuPOwlHp5HfcR3LBKyB7smTnbq9Y')
+    it 'should generate password' do
+      scope.stubs(:function_fqdn_rand_string).with([8]).returns('abcdefgh')
+      expect(scope.function_openldap_password(['foo'])).to eq("{SSHA}3RXLE64s+3ytIRdJYu9eoU8O/alhYmNkZWZnaA==")
     end
   end
 
   context 'when given a secret and a scheme' do
-    it 'should execute slappasswd on them' do
-      Puppet::Util::Execution.stubs(:execute).with([
-        'slappasswd', '-s', 'foo', '-h', '{MD5}'
-      ]).returns("{MD5}rL0Y20zC+Fzt72VPzMSk2A==\n")
-      expect(scope.function_openldap_password(['foo', '{MD5}'])).to eq('{MD5}rL0Y20zC+Fzt72VPzMSk2A==')
+    it 'should generate CRYPT password' do
+      scope.stubs(:function_fqdn_rand_string).with([2]).returns('ab')
+      expect(scope.function_openldap_password(['foo', 'CRYPT'])).to eq("{CRYPT}abQ9KY.KfrYrc")
+    end
+    it 'should generate MD5 password' do
+      expect(scope.function_openldap_password(['foo', 'MD5'])).to eq("{MD5}acbd18db4cc2f85cedef654fccc4a4d8")
+    end
+    it 'should generate SMD5 password' do
+      scope.stubs(:function_fqdn_rand_string).with([8]).returns('abcdefgh')
+      expect(scope.function_openldap_password(['foo', 'SMD5'])).to eq("{SMD5}NAYSvQYSIRYBLCM8U6MUc2FiY2RlZmdo")
+    end
+    it 'should generate SSHA password' do
+      scope.stubs(:function_fqdn_rand_string).with([8]).returns('abcdefgh')
+      expect(scope.function_openldap_password(['foo', 'SSHA'])).to eq("{SSHA}3RXLE64s+3ytIRdJYu9eoU8O/alhYmNkZWZnaA==")
+    end
+    it 'should generate SHA password' do
+      expect(scope.function_openldap_password(['foo', 'SHA'])).to eq("{SHA}0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
     end
   end
 end


### PR DESCRIPTION
The code is mostly copied from the openldap_database type's rootpw property
The salt is generated using fqdn_rand_string to generate idempotent results