### PR TITLE
Fix how default provider is defined

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -7,7 +7,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -7,7 +7,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_dbindex/olc.rb
+++ b/lib/puppet/provider/openldap_dbindex/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_global_conf/olc.rb
+++ b/lib/puppet/provider/openldap_global_conf/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_module/olc.rb
+++ b/lib/puppet/provider/openldap_module/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_schema/olc.rb
+++ b/lib/puppet/provider/openldap_schema/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => :debian, :osfamily => :redhat
+  defaultfor :osfamily => [:debian, :redhat]
 
   mk_resource_methods
 


### PR DESCRIPTION
Without this fix the following is produced on Puppet 5.3.3

```
/opt/puppetlabs/puppet/cache/lib/puppet/provider/openldap_global_conf/olc.rb:9: warning: key :osfamily is duplicated and overwritten on line 9
/opt/puppetlabs/puppet/cache/lib/puppet/provider/openldap_database/olc.rb:10: warning: key :osfamily is duplicated and overwritten on line 10
/opt/puppetlabs/puppet/cache/lib/puppet/provider/openldap_schema/olc.rb:10: warning: key :osfamily is duplicated and overwritten on line 10
/opt/puppetlabs/puppet/cache/lib/puppet/provider/openldap_access/olc.rb:10: warning: key :osfamily is duplicated and overwritten on line 10
/opt/puppetlabs/puppet/cache/lib/puppet/provider/openldap_module/olc.rb:9: warning: key :osfamily is duplicated and overwritten on line 9
/opt/puppetlabs/puppet/cache/lib/puppet/provider/openldap_overlay/olc.rb:9: warning: key :osfamily is duplicated and overwritten on line 9
```