### PR TITLE
Fix title patterns to no longer use unsupported proc

### DIFF
--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -36,51 +36,51 @@ Puppet::Type.newtype(:openldap_access) do
       [
         /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :position, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :position ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
-          [ :suffix, lambda{|x| x} ],
+          [ :suffix ],
         ],
       ],
       [
-        /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+)\s+)$/,
+        /^(\{(\d+)\}to\s+(\S+)\s+(by\s+.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :position, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :position ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
         ],
       ],
       [
         /^(to\s+(\S+)\s+(by\s+.+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
-          [ :suffix, lambda{|x| x} ],
+          [ :suffix ],
         ],
       ],
       [
         /^(to\s+(\S+)\s+(by\s+.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :what, lambda{|x| x} ],
+          [ :name ],
+          [ :what ],
           [ :access, lambda{ |x| a=[]; x.split(/(?= by .+)/).each { |b| a << b.lstrip }; a } ],
         ],
       ],
       [
         /^((\d+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :position, lambda{|x| x} ],
-          [ :suffix, lambda{|x| x} ],
+          [ :name ],
+          [ :position ],
+          [ :suffix ],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [ :name ],
         ],
       ],
     ]

--- a/lib/puppet/type/openldap_dbindex.rb
+++ b/lib/puppet/type/openldap_dbindex.rb
@@ -25,15 +25,15 @@ Puppet::Type.newtype(:openldap_dbindex) do
       [
         /^((\S+)\s+on\s+(.+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :attribute, lambda{|x| x} ],
-          [ :suffix, lambda{|x| x} ],
+          [ :name ],
+          [ :attribute ],
+          [ :suffix ],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [ :name ],
         ],
       ],
     ]

--- a/lib/puppet/type/openldap_overlay.rb
+++ b/lib/puppet/type/openldap_overlay.rb
@@ -28,15 +28,15 @@ Puppet::Type.newtype(:openldap_overlay) do
       [
         /^((\S+)\s+on\s+(\S+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :overlay, lambda{|x| x} ],
-          [ :suffix, lambda{|x| x} ],
+          [ :name ],
+          [ :overlay ],
+          [ :suffix ],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [ :name ],
         ],
       ],
     ]

--- a/spec/unit/puppet/type/openldap_acess_spec.rb
+++ b/spec/unit/puppet/type/openldap_acess_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:openldap_access) do
+  describe 'namevar title patterns' do
+    it 'should handle componsite name' do
+      access = described_class.new(:name => 'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:name]).to eq('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
+      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+    end
+
+    it 'should handle componsite name with position' do
+      access = described_class.new(:name => '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:position]).to eq('0')
+      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
+      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+    end
+
+    it 'should handle componsite name with position' do
+      access = described_class.new(:name => '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com')
+      expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com')
+      expect(access[:position]).to eq('0')
+      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
+      expect(access[:access]).to eq(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+      expect(access[:suffix]).to eq('dc=example,dc=com')
+    end
+  end
+end


### PR DESCRIPTION
Currently the title patterns with proc prevent `puppet generate types` from working:

```
Error: /etc/puppetlabs/code/environments/production/modules/openldap/lib/puppet/type/openldap_access.rb: title patterns that use procs are not supported.
Error: /etc/puppetlabs/code/environments/production/modules/openldap/lib/puppet/type/openldap_dbindex.rb: title patterns that use procs are not supported.
Error: /etc/puppetlabs/code/environments/production/modules/openldap/lib/puppet/type/openldap_overlay.rb: title patterns that use procs are not supported.
```
https://tickets.puppetlabs.com/browse/MODULES-4505?focusedCommentId=418416&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-418416
https://github.com/treydock/puppet-module-keycloak/pull/21