### PR TITLE
fixing issue #215,#184, allow space before 'to' statement in ACL, ign…

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -25,7 +25,7 @@ Puppet::Type.
         when /^olcSuffix: /
           suffix = line.split(' ')[1]
         when /^olcAccess: /
-          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?)(\s+by\s+.*)+$/).captures
+          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}\s*to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?)(\s+by\s+.*)+$/).captures
           access = []
           bys.split(/(?= by .+)/).each { |b|
             access << b.lstrip
@@ -88,7 +88,7 @@ Puppet::Type.
       return 'olcDatabase={-1}frontend,cn=config'
     elsif suffix == 'cn=config'
       return 'olcDatabase={0}config,cn=config'
-    elsif suffix == 'cn=monitor'
+    elsif suffix.downcase == 'cn=monitor'
       slapcat('(olcDatabase=monitor)').split("\n").collect do |line|
         if line =~ /^dn: /
           return line.split(' ')[1]

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -36,7 +36,7 @@ Puppet::Type.
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
-          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/).captures
+          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/i).captures
         when /^olcDbDirectory: /
           directory = line.split(' ')[1]
         when /^olcRootDN: /


### PR DESCRIPTION
- when dn has an uppercase in name the regex match fails, so ignore it
- when acl has a valid space before the 'to'-statement (which is valid) the regex match fails, so allow it