### PR TITLE
Fix openldap_overlap to perform add operation when adding new options

### DIFF
--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -171,10 +171,15 @@ Puppet::Type.
         end
         # Add current options
         @property_flush[:options].each do |k, v|
-          if v.is_a?(Array)
-            t << "replace: #{k}\n#{v.collect { |x| "#{k}: #{x}" }.join("\n")}\n-\n"
+          if (@property_hash[:options] || {}).member?(k)
+            action = 'replace'
           else
-            t << "replace: #{k}\n#{k}: #{v}\n-\n"
+            action = 'add'
+          end
+          if v.is_a?(Array)
+            t << "#{action}: #{k}\n#{v.collect { |x| "#{k}: #{x}" }.join("\n")}\n-\n"
+          else
+            t << "#{action}: #{k}\n#{k}: #{v}\n-\n"
           end
         end
       end

--- a/spec/acceptance/overlay_spec.rb
+++ b/spec/acceptance/overlay_spec.rb
@@ -20,7 +20,32 @@ describe 'openldap::server::overlay' do
       EOS
 
       apply_manifest(pp, :catch_failures => true)
-      #apply_manifest(pp, :catch_changes => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  context 'options defined' do
+    it 'adds option to overlay' do
+      pp = <<-EOS
+      class { 'openldap::server': }
+      openldap::server::database { 'dc=foo,dc=bar':
+        ensure => present,
+      }
+      ->
+      openldap::server::module { 'memberof':
+        ensure => present,
+      }
+      ->
+      openldap::server::overlay { 'memberof on dc=foo,dc=bar':
+        ensure  => present,
+        options => {
+          'olcMemberOfGroupOC' => 'groupOfNames',
+        }
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
     end
   end
 end


### PR DESCRIPTION
Fixes #224 

Without the change to provider and using new test, able to reproduce the issue:

```
centos-7-x64 09:23:59$ puppet apply --strict_variables --verbose --detailed-exitcodes --order=random /tmp/apply_manifest.pp.57uZ37
  Info: Loading facts
  Warning: /etc/puppetlabs/puppet/hiera.yaml: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5
     (in /etc/puppetlabs/puppet/hiera.yaml)
  Notice: Compiled catalog for centos-7-x64 in environment production in 0.33 seconds
  Info: Applying configuration version '1523021051'
  Notice: /Stage[main]/Main/Openldap::Server::Overlay[memberof on dc=foo,dc=bar]/Openldap_overlay[memberof on dc=foo,dc=bar]/options: defined 'options' as '{"olcMemberOfGroupOC"=>"groupOfNames"}'
  Error: /Stage[main]/Main/Openldap::Server::Overlay[memberof on dc=foo,dc=bar]/Openldap_overlay[memberof on dc=foo,dc=bar]: Could not evaluate: LDIF content:
  dn: olcOverlay={0}memberof,olcDatabase={3}hdb,cn=config
  changetype: modify
  replace: olcMemberOfGroupOC
  olcMemberOfGroupOC: groupOfNames
  -
  
  Error message: Execution of '/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/openldap_overlay20180406-1205-wzl84e' returned 80: SASL/EXTERNAL authentication started
  SASL username: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
  SASL SSF: 0
  ldap_modify: Other (e.g., implementation specific) error (80)
  	additional info: modify/delete: olcMemberOfGroupOC: no such attribute
  modifying entry "olcOverlay={0}memberof,olcDatabase={3}hdb,cn=config"
  Notice: Applied catalog in 0.22 seconds
```

Using the provider change resolves the acceptance test.