### PR TITLE
Fix setting ACL if they had been set before

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -57,7 +57,7 @@ Puppet::Type.
       if provider = accesses.find{ |access|
         if resources[name][:position]
           access.suffix == resources[name][:suffix] &&
-          access.position == resources[name][:position]
+          access.position == resources[name][:position].to_s
         else
           access.suffix == resources[name][:suffix] &&
           access.access.flatten == resources[name][:access].flatten &&
@@ -105,7 +105,23 @@ Puppet::Type.
   def getDn(*args); self.class.getDn(*args); end
 
   def exists?
-    @property_hash[:ensure] == :present
+    if resource[:position]
+      access = {
+        :suffix   => resource[:suffix],
+        :position => resource[:position].to_s
+      }
+    else
+      access = {
+        :suffix => resource[:suffix],
+        :access => resource[:access].flatten,
+        :what   => resource[:what]
+      }
+    end
+    accesses = self.class.instances.map { |acc|
+      acc_hash = acc.instance_variable_get(:@property_hash)
+      acc_hash.select { |k,v| access.key?(k) }
+    }
+    accesses.include?(access)
   end
 
   def create

--- a/spec/acceptance/openldap__server__access_spec.rb
+++ b/spec/acceptance/openldap__server__access_spec.rb
@@ -35,6 +35,16 @@ describe 'openldap::server::access' do
           suffix  => 'dc=example,dc=com',
           require => Openldap::Server::Database['dc=example,dc=com'],
         }
+        ::openldap::server::access { 'root':
+          what    => '*',
+          access  => [
+            'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+            'by * break'
+          ],
+          suffix  => 'dc=example,dc=com',
+          position => 0,
+          require => Openldap::Server::Database['dc=example,dc=com'],
+        }
       EOS
 
       apply_manifest(pp, :catch_failures => true)


### PR DESCRIPTION
This PR fixes ACL setting - if there was an entry that has to be update then resource must not be created but updated. Result before fix:
`Error: LDIF content:
dn: olcDatabase={1}monitor,cn=config
add: olcAccess
olcAccess: {0}to *
  by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage
  by * break

Error message: Execution of '/usr/bin/ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/openldap_access20180907-14186-1lgqm23' returned 20: SASL/EXTERNAL authentication started
SASL username: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
SASL SSF: 0
ldap_modify: Type or value exists (20)
        additional info: modify/add: olcAccess: value #0 already exists`