### PR TITLE
Fix usage of slapcat when removing an overlay

### DIFF
--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -205,7 +205,7 @@ Puppet::Type.
     path = default_confdir  + "/" + getPath("olcOverlay={#{@property_hash[:index]}}#{resource[:overlay]},#{getDn(resource[:suffix])}")
     File.delete(path)
 
-    slapcat("ldap:///(objectClass=olcOverlayConfig)", getDn(resource[:suffix])).
+    slapcat("(objectClass=olcOverlayConfig)", getDn(resource[:suffix])).
       split("\n").
       select { |line| line =~ /^dn: / }.
       select { |dn| dn.match(/^dn: olcOverlay=\{(\d+)\}(.+),#{Regexp.quote(getDn(resource[:suffix]))}$/).captures[0].to_i > @property_hash[:index] }.


### PR DESCRIPTION
Without this fix the command that gets executed is this:

```
/usr/sbin/slapcat -b cn=config -o ldif-wrap=no -H ldap:///olcDatabase={2}mdb,cn=config???ldap:///(objectClass=olcOverlayConfig)
```

Removing `ldap:///` before the filter portion fixes the command.  This makes the use of the `slapcat` function match everywhere else in the code.