### PR TITLE
Add socks support

### DIFF
--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -70,6 +70,8 @@ Puppet::Type.
     case resource[:overlay]
     when 'memberof'
       t << "objectClass: olcMemberOf\n"
+    when 'sock'
+      t << "objectClass: olcOvSocketConfig\n"
     when 'ppolicy'
       t << "objectClass: olcPPolicyConfig\n"
     when 'dynlist'


### PR DESCRIPTION
  Add the support for slapd-sock overlay

This overlay allow you to send everything slapd does to a unix-socket. The purpose of this feature is to catch event from the socket and send (for example) to a rabbitmq server