### PR TITLE
Enable usage of puppetlabs-stdlib 5.x.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.1 <5.0.0"
+      "version_requirement": ">=4.13.1 < 6.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_core",


### PR DESCRIPTION
This patch enables using the puppetlabs-stdlib module version 5.
Fixes https://github.com/camptocamp/puppet-openldap/issues/237
As there are no breaking changes in version 5.x that affect this
module, running these versions is fine.
https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/CHANGELOG.md

I have been running this module along with stdlib 5.1.0 and have not encountered any errors (or warnings).