### PR TITLE
Fix regexp in access_wrapper

### DIFF
--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -33,7 +33,7 @@ define openldap::server::access_wrapper (
       {
         "#{position} on #{@suffix}" => {
           "position" => position,
-          "what"     => to[/.*to (.*)/,1],
+          "what"     => to[/.*\bto (.*)/,1],
           "access"   => access,
           "suffix"   => "#{@suffix}",
         }


### PR DESCRIPTION
The `to` field to catch the `what` part for the acl must be forced at
word boundary. Otherway, an expression like `to attrs=jpegphoto
filter=...` the catched `to` is the final part of `jpegphoto`, not the
wanted `to`.

For example, I have an acl rule like:
```
    'to attrs=jpegPhoto filter=irisUserPrivateAttribute=jpegPhoto' => [
      'by group.exact=cn=LdapGate,ou=Groups,ou=Management,o=SlapdRoot none',
      'by * break',
    ],
```
with the regular expresion`"what"     => to[/.*to (.*)/,1],` the `what` part is matched with `filter=irisUserPrivateAttribute=jpegPhoto` which is only a part of the real `waht`.
This PR fixes this problem