### PR TITLE
Add support for back_ldap and specific values of attrs in ACLs

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -25,7 +25,7 @@ Puppet::Type.
         when /^olcSuffix: /
           suffix = line.split(' ')[1]
         when /^olcAccess: /
-          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?)(\s+by\s+.*)+$/).captures
+          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+value=\S+)?)(\s+by\s+.*)+$/).captures
           access = []
           bys.split(/(?= by .+)/).each { |b|
             access << b.lstrip

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -25,7 +25,7 @@ Puppet::Type.
         when /^olcSuffix: /
           suffix = line.split(' ')[1]
         when /^olcAccess: /
-          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+value=\S+)?)(\s+by\s+.*)+$/).captures
+          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+val=\S+)?)(\s+by\s+.*)+$/).captures
           access = []
           bys.split(/(?= by .+)/).each { |b|
             access << b.lstrip

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -12,7 +12,7 @@ Puppet::Type.
   mk_resource_methods
 
   def self.instances
-    databases = slapcat("(|(olcDatabase=monitor)(olcDatabase={0}config)(&(objectClass=olcDatabaseConfig)(|(objectClass=olcBdbConfig)(objectClass=olcHdbConfig)(objectClass=olcMdbConfig)(objectClass=olcMonitorConfig)(objectClass=olcRelayConfig))))")
+    databases = slapcat("(|(olcDatabase=monitor)(olcDatabase={0}config)(&(objectClass=olcDatabaseConfig)(|(objectClass=olcBdbConfig)(objectClass=olcHdbConfig)(objectClass=olcMdbConfig)(objectClass=olcMonitorConfig)(objectClass=olcRelayConfig)(objectClass=olcLDAPConfig))))")
 
     databases.split("\n\n").collect do |paragraph|
       suffix = nil
@@ -36,7 +36,7 @@ Puppet::Type.
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
-          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay)$/i).captures
+          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay|ldap)$/).captures
         when /^olcDbDirectory: /
           directory = line.split(' ')[1]
         when /^olcRootDN: /
@@ -221,6 +221,9 @@ Puppet::Type.
       t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
     when "monitor"
       # WRITE HERE FOR MONITOR ONLY
+    when "ldap"
+      # WRITE HERE FOR LDAP ONLY
+      t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
     else
       t << "olcDbDirectory: #{resource[:directory]}\n" if resource[:directory]
       t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -22,7 +22,7 @@ Puppet::Type.newtype(:openldap_database) do
 
   newproperty(:backend) do
     desc "The name of the backend."
-    newvalues('bdb', 'hdb', 'mdb', 'monitor', 'config', 'relay')
+    newvalues('bdb', 'hdb', 'mdb', 'monitor', 'config', 'relay', 'ldap')
     defaultto do
       case Facter.value(:osfamily)
       when 'Debian'
@@ -55,7 +55,7 @@ Puppet::Type.newtype(:openldap_database) do
   newproperty(:directory) do
     desc "The directory where the BDB files containing this database and associated indexes live."
     defaultto do
-      unless [ "monitor" , "config", "relay" ].include? "#{@resource[:backend]}"
+      unless [ "monitor" , "config", "relay", "ldap" ].include? "#{@resource[:backend]}"
         '/var/lib/ldap'
       end
     end
@@ -137,7 +137,7 @@ Puppet::Type.newtype(:openldap_database) do
 
     newvalues(:true, :false)
     defaultto do
-      if [ "monitor" , "config", "relay" ].include? "#{@resource[:backend]}"
+      if [ "monitor" , "config", "relay", "ldap" ].include? "#{@resource[:backend]}"
         :false
       else
         :true

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -32,6 +32,7 @@ define openldap::server::database(
     'monitor' => undef,
     'config'  => undef,
     'relay'   => undef,
+    'ldap'    => undef,
     default   => $directory ? {
       undef   => '/var/lib/ldap',
       default => $directory,
@@ -51,7 +52,7 @@ define openldap::server::database(
     Openldap::Server::Database['dc=my-domain,dc=com'] -> Openldap::Server::Database[$title]
   }
 
-  if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' {
+  if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' and $backend != 'ldap' {
     file { $manage_directory:
       ensure => directory,
       owner  => $::openldap::server::owner,

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -117,6 +117,25 @@ describe 'openldap::server::database' do
     end
   end
 
+  context 'with a ldap db' do
+    it 'creates a ldap database' do
+      pp = <<-EOS
+      class {'openldap::server': }
+      openldap::server::module {'back_ldap':
+        ensure => present,
+      }
+      openldap::server::database { 'dc=bar,dc=com':
+        ensure => present,
+        backend => 'ldap',
+        require => Openldap::Server::Module['back_ldap'],
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
   context 'cn=config with a rootdn and rootpw' do
     it 'change a config password database' do
       tmpdir = default.tmpdir('openldap')

--- a/spec/unit/puppet/type/openldap_acess_spec.rb
+++ b/spec/unit/puppet/type/openldap_acess_spec.rb
@@ -27,9 +27,9 @@ describe Puppet::Type.type(:openldap_access) do
     end
 
     it 'should handle specific value of attr' do
-      access = described_class.new(:name => 'to attrs=objectClass value=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:name]).to eq('to attrs=objectClass value=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:what]).to eq('attrs=objectClass value=posixAccount')
+      access = described_class.new(:name => 'to attrs=objectClass val=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:name]).to eq('to attrs=objectClass val=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:what]).to eq('attrs=objectClass val=posixAccount')
       expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
     end
   end

--- a/spec/unit/puppet/type/openldap_acess_spec.rb
+++ b/spec/unit/puppet/type/openldap_acess_spec.rb
@@ -25,6 +25,13 @@ describe Puppet::Type.type(:openldap_access) do
       expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
       expect(access[:suffix]).to eq('dc=example,dc=com')
     end
+
+    it 'should handle specific value of attr' do
+      access = described_class.new(:name => 'to attrs=objectClass value=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:name]).to eq('to attrs=objectClass value=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:what]).to eq('attrs=objectClass value=posixAccount')
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
+    end
   end
 
   describe 'access' do

--- a/spec/unit/puppet/type/openldap_database_spec.rb
+++ b/spec/unit/puppet/type/openldap_database_spec.rb
@@ -52,7 +52,7 @@ describe Puppet::Type.type(:openldap_database) do
     end
 
     describe "backend" do
-      ['bdb', 'hdb', 'mdb', 'monitor', 'config', 'relay'].each do |b|
+      ['bdb', 'hdb', 'mdb', 'monitor', 'config', 'relay', 'ldap'].each do |b|
         it "should support #{b} as a value for backend" do
           expect { described_class.new(:name => 'foo', :backend => b) }.to_not raise_error
         end


### PR DESCRIPTION
There are two fixes in this PR. The first simply adds the ability to add specific values of attributes in ACLs per the end of section 8.3.1 of https://www.openldap.org/doc/admin24/access-control.html .

The other fix is adding support for the back-ldap backend, which allows for slapd to act as a passthrough proxy.

Both of these patches have been running in production at Mozilla for years, so I figured it's time I PR them back so others can make use of them.