### PR TITLE
add sssvlv overlay compatibility

### DIFF
--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -96,6 +96,8 @@ Puppet::Type.
       t << "objectClass: olcOvSocketConfig\n"
     when 'smbk5pwd'
       t << "objectClass: olcSmbK5PwdConfig\n"
+    when 'sssvlv'
+      t << "objectClass: olcSssVlvConfig\n"
     end
     t << "olcOverlay: #{resource[:overlay]}\n"
     if resource[:options]


### PR DESCRIPTION
We can add sssvlv module but not configure it.
To configure, it is just required to create overlay with appropriate objectClass.