### PR TITLE
declare this module as compatible with ubuntu1804

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {


### PR DESCRIPTION
As acceptance tests are already running about ubuntu1804, with `rspec-puppet-facts` in unit tests, adding this OS in metadata should be enough to declare this module accepting the OS.