### PR TITLE
update dependencies and Puppet version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,19 +10,19 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.13.1 < 6.0.0"
+      "version_requirement": ">=4.13.1 < 7.0.0"
     },
     {
       "name": "puppetlabs/augeas_core",
-      "version_requirement": "1.x"
+      "version_requirement": ">=1.0.0 < 2.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_core",
-      "version_requirement": "2.x"
+      "version_requirement": ">=2.0.0 < 3.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_shellvar",
-      "version_requirement": "2.x"
+      "version_requirement": ">=2.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 6.0.0"
+      "version_requirement": ">= 5.5.10 < 6.0.0"
     }
   ],
   "pdk-version": "1.15.0",


### PR DESCRIPTION
allow puppetlabs/stdlib 6.x, herculesteam/augeasproviders_shellvar 4.x, raise lower Puppet bound to 5.5.10

Fixes #248