### PR TITLE
Catch olcAccess regex parse failures

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -25,7 +25,11 @@ Puppet::Type.
         when /^olcSuffix: /
           suffix = line.split(' ')[1]
         when /^olcAccess: /
-          position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+val=\S+)?)(\s+by\s+.*)+$/).captures
+          begin
+            position, what, bys = line.match(/^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+val=\S+)?)(\s+by\s+.*)+$/).captures
+          rescue
+            raise Puppet::Error, "Failed to parse olcAccess for suffix '#{suffix}': #{line}"
+          end
           access = []
           bys.split(/(?= by .+)/).each { |b|
             access << b.lstrip


### PR DESCRIPTION
Return an informative error to the user.
Otherwise, this will throw:
"undefined method `captures' for nil:NilClass""
which doesn't indicate where is the problem

This should help assist users who see this in #184 