### PR TITLE
Add support for FreeBSD

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -7,7 +7,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => [:debian, :redhat]
+  defaultfor :osfamily => [:debian, :freebsd, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_database/augeas.rb
+++ b/lib/puppet/provider/openldap_database/augeas.rb
@@ -9,6 +9,8 @@ Puppet::Type.type(:openldap_database).provide(:augeas, :parent => Puppet::Type.t
       '/etc/openldap/slapd.conf'
     when 'Archlinux'
       '/etc/openldap/slapd.conf'
+    when 'FreeBSD'
+      '/usr/local/etc/openldap/slapd.conf'
     end
   }
 

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -7,7 +7,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => [:debian, :redhat]
+  defaultfor :osfamily => [:debian, :freebsd, :redhat]
 
   mk_resource_methods
 
@@ -151,7 +151,12 @@ Puppet::Type.
   end
 
   def destroy
-    default_confdir = Facter.value(:osfamily) == 'Debian' ? '/etc/ldap/slapd.d' : Facter.value(:osfamily) == 'RedHat' ? '/etc/openldap/slapd.d' : nil
+    default_confdir = case Facter.value(:osfamily)
+                      when 'Debian' then '/etc/ldap/slapd.d'
+                      when 'RedHat' then '/etc/openldap/slapd.d'
+                      when 'FreeBSD' then '/usr/local/etc/openldap/slapd.d'
+                      else nil
+                      end
     backend = @property_hash[:backend]
 
     fetch_index

--- a/lib/puppet/provider/openldap_dbindex/olc.rb
+++ b/lib/puppet/provider/openldap_dbindex/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => [:debian, :redhat]
+  defaultfor :osfamily => [:debian, :freebsd, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_global_conf/olc.rb
+++ b/lib/puppet/provider/openldap_global_conf/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => [:debian, :redhat]
+  defaultfor :osfamily => [:debian, :freebsd, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_module/olc.rb
+++ b/lib/puppet/provider/openldap_module/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => [:debian, :redhat]
+  defaultfor :osfamily => [:debian, :freebsd, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -6,7 +6,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => [:debian, :redhat]
+  defaultfor :osfamily => [:debian, :freebsd, :redhat]
 
   mk_resource_methods
 
@@ -205,7 +205,12 @@ Puppet::Type.
   end
 
   def destroy
-    default_confdir = Facter.value(:osfamily) == 'Debian' ? '/etc/ldap/slapd.d' : Facter.value(:osfamily) == 'RedHat' ? '/etc/openldap/slapd.d' : nil
+    default_confdir = case Facter.value(:osfamily)
+                      when 'Debian' then '/etc/ldap/slapd.d'
+                      when 'RedHat' then '/etc/openldap/slapd.d'
+                      when 'FreeBSD' then '/usr/local/etc/openldap/slapd.d'
+                      else nil
+                      end
 
     `service slapd stop`
     path = default_confdir  + "/" + getPath("olcOverlay={#{@property_hash[:index]}}#{resource[:overlay]},#{getDn(resource[:suffix])}")

--- a/lib/puppet/provider/openldap_schema/olc.rb
+++ b/lib/puppet/provider/openldap_schema/olc.rb
@@ -7,7 +7,7 @@ Puppet::Type.
 
   # TODO: Use ruby bindings (can't find one that support IPC)
 
-  defaultfor :osfamily => [:debian, :redhat]
+  defaultfor :osfamily => [:debian, :freebsd, :redhat]
 
   mk_resource_methods
 

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -48,6 +48,8 @@ Puppet::Type.newtype(:openldap_database) do
         else
           'hdb'
         end
+      when 'FreeBSD'
+        'mdb'
       end
     end
   end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class openldap::params {
         $server_service_hasstatus = true
       }
       $utils_package            = 'ldap-utils'
+      $escape_ldapi_ifs         = false
     }
     'RedHat': {
       $client_package           = 'openldap'
@@ -31,6 +32,7 @@ class openldap::params {
       }
       $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'
+      $escape_ldapi_ifs         = false
     }
     'Archlinux': {
       $client_package           = 'openldap'
@@ -43,6 +45,20 @@ class openldap::params {
       $server_service           = 'slapd'
       $server_service_hasstatus = true
       $utils_package            = undef
+      $escape_ldapi_ifs         = false
+    }
+    'FreeBSD': {
+      $client_package           = 'openldap-sasl-client'
+      $client_conffile          = '/usr/local/etc/openldap/ldap.conf'
+      $server_confdir           = '/usr/local/etc/openldap/slapd.d'
+      $server_conffile          = '/usr/local/etc/openldap/slapd.conf'
+      $server_group             = 'ldap'
+      $server_owner             = 'ldap'
+      $server_package           = 'openldap-sasl-server'
+      $server_service           = 'slapd'
+      $server_service_hasstatus = true
+      $utils_package            = undef
+      $escape_ldapi_ifs         = true
     }
     default: {
       fail "Operating System family ${::osfamily} not supported"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,6 +17,7 @@ class openldap::server(
   $ldap_ifs                                = ['/'],
   $ldaps_ifs                               = [],
   $ldapi_ifs                               = ['/'],
+  Boolean $escape_ldapi_ifs                = $openldap::params::escape_ldapi_ifs,
 ) inherits ::openldap::params {
 
   class { '::openldap::server::install': }

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -5,6 +5,7 @@ define openldap::server::schema(
     'Debian' => "/etc/ldap/schema/${title}.schema",
     'Redhat' => "/etc/openldap/schema/${title}.schema",
     'Archlinux' => "/etc/openldap/schema/${title}.schema",
+    'FreeBSD' => "/usr/local/etc/openldap/schema/${title}.schema",
   }
 ) {
 

--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,13 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "11",
+        "12"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
This PR add support for FreeBSD.

The following items must be fixed before this PR can leave the draft state:
* [x] Fix errors raised when applying a catalog on FreeBSD;
* [x] URL-encode UNIX socket paths as expected by the slapd man page;
* [x] Manage FreeBSD's `slapd_flags` in `rc.conf`;
* [x] Manage FreeBSD's `slapd_sockets` in `rc.conf`;
* [x] Manage FreeBSD's `slapd_cn_config` in `rc.conf`.

The following items are valuable for using the module on FreeBSD but can be circumvent with sufficient efforts:
* [ ] Have a openldap-sasl-server package at hand (FreeBSD does not currently provide an openldap package with SASL support which is required for updating the `cn=config` with EXTERNAL mech);
* [ ] Handle the initial setup when using olc and no `slapd.d` directory exist (which prevents the service from starting).

The following items might be good additions I will be pleased to submit into separate PRs. Please tell me if you are interested in them:
* [ ] Trim the list of served URLs;
* [ ] Reorder OS-specific code by sorting the cases alphabetically;
* [ ] Remove the redundant `::` (`$::foo::bar` → `$foo::bar`) which are not required anymore since Puppet 3.8 with the future parser (part for Puppet 4+);
* [ ] Switch from `params.pp` to hiera data.