### PR TITLE
Remove dead code

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,11 +10,6 @@ class openldap::params {
       $server_owner             = 'openldap'
       $server_package           = 'slapd'
       $server_service           = 'slapd'
-      if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '5') <= 0 {
-        $server_service_hasstatus = false
-      } else {
-        $server_service_hasstatus = true
-      }
       $utils_package            = 'ldap-utils'
       $escape_ldapi_ifs         = false
       # added to fix spec tests
@@ -35,7 +30,6 @@ class openldap::params {
         '5' => 'ldap',
         default => 'slapd',
       }
-      $server_service_hasstatus = true
       $utils_package            = 'openldap-clients'
       $escape_ldapi_ifs         = false
       # added to fix spec tests
@@ -53,7 +47,6 @@ class openldap::params {
       $server_owner             = 'ldap'
       $server_package           = 'openldap'
       $server_service           = 'slapd'
-      $server_service_hasstatus = true
       $utils_package            = undef
       $escape_ldapi_ifs         = false
       # added to fix spec tests
@@ -71,7 +64,6 @@ class openldap::params {
       $server_owner             = 'ldap'
       $server_package           = 'openldap-sasl-server'
       $server_service           = 'slapd'
-      $server_service_hasstatus = true
       $utils_package            = undef
       $escape_ldapi_ifs         = true
       # added to fix spec tests

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,6 +4,7 @@ class openldap::server(
   $confdir                                          = $openldap::params::server_confdir,
   $conffile                                         = $openldap::params::server_conffile,
   $service                                          = $openldap::params::server_service,
+  Optional[Boolean] $service_hasstatus              = undef,
   $owner                                            = $openldap::params::server_owner,
   $group                                            = $openldap::params::server_group,
   $enable                                           = true,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,7 +4,6 @@ class openldap::server(
   $confdir                                          = $openldap::params::server_confdir,
   $conffile                                         = $openldap::params::server_conffile,
   $service                                          = $openldap::params::server_service,
-  $service_hasstatus                                = $openldap::params::server_service_hasstatus,
   $owner                                            = $openldap::params::server_owner,
   $group                                            = $openldap::params::server_group,
   $enable                                           = true,

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -18,9 +18,8 @@ class openldap::server::service {
   }
 
   service { $::openldap::server::service:
-    ensure    => $ensure,
-    provider  => $provider,
-    enable    => $::openldap::server::enable,
-    hasstatus => $::openldap::server::service_hasstatus,
+    ensure   => $ensure,
+    provider => $provider,
+    enable   => $::openldap::server::enable,
   }
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -18,8 +18,9 @@ class openldap::server::service {
   }
 
   service { $::openldap::server::service:
-    ensure   => $ensure,
-    provider => $provider,
-    enable   => $::openldap::server::enable,
+    ensure    => $ensure,
+    provider  => $provider,
+    enable    => $::openldap::server::enable,
+    hasstatus => $::openldap::server::service_hasstatus,
   }
 }


### PR DESCRIPTION
The module metadata.json indicates it support Debian 8, 9 and 10; but this code was checking for Debian 5 (Lenny, which has reached EOL and is [unsupported since February 6th, 2012][1])

[1]: https://www.debian.org/releases/lenny/