### PR TITLE
Remove syncrepl property to make a slave a master

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -26,11 +26,11 @@ Puppet::Type.
       sizelimit = nil
       dbmaxsize = nil
       timelimit = nil
-      updateref = nil
+      updateref = ''
       dboptions = {}
       mirrormode = nil
       syncusesubentry = nil
-      syncrepl = nil
+      syncrepl = []
       limits = []
       security = {}
       paragraph.gsub("\n ", "").split("\n").collect do |line|
@@ -235,7 +235,7 @@ Puppet::Type.
     t << "olcSizeLimit: #{resource[:sizelimit]}\n" if resource[:sizelimit]
     t << "olcDbMaxSize: #{resource[:dbmaxsize]}\n" if resource[:dbmaxsize]
     t << "olcTimeLimit: #{resource[:timelimit]}\n" if resource[:timelimit]
-    t << "olcUpdateref: #{resource[:updateref]}\n" if resource[:updateref]
+    t << "olcUpdateref: #{resource[:updateref]}\n" if resource[:updateref] and !resource[:updateref].empty?
     if resource[:dboptions]
       resource[:dboptions].each do |k, v|
         case k
@@ -254,7 +254,7 @@ Puppet::Type.
         end
       end
     end
-    t << resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n") + "\n" if resource[:syncrepl]
+    t << resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n") + "\n" if resource[:syncrepl] and !resource[:syncrepl].empty?
     t << "olcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:mirrormode]
     t << "olcSyncUseSubentry: #{resource[:syncusesubentry]}\n" if resource[:syncusesubentry]
     t << "#{resource[:limits].collect { |x| "olcLimits: #{x}" }.join("\n")}\n" if resource[:limits] and !resource[:limits].empty?
@@ -403,8 +403,10 @@ Puppet::Type.
           end
         end
       end
-      t << "replace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
-      t << "replace: olcUpdateref\nolcUpdateref: #{resource[:updateref]}\n-\n" if @property_flush[:updateref]
+      t << "delete: olcSyncrepl\n-\n"                                                                         if @property_flush[:updateref] and resource[:updateref].empty?
+      t << "replace: olcSyncrepl\n#{resource[:syncrepl].collect { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]  and !resource[:updateref].empty?
+      t << "delete: olcUpdateref\n-\n"                                                                        if @property_flush[:updateref] and resource[:updateref].empty?
+      t << "replace: olcUpdateref\nolcUpdateref: #{resource[:updateref]}\n-\n"                                if @property_flush[:updateref] and !resource[:updateref].empty?
       t << "replace: olcMirrorMode\nolcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:mirrormode]
       t << "replace: olcSyncUseSubentry\nolcSyncUseSubentry: #{resource[:syncusesubentry]}\n-\n" if @property_flush[:syncusesubentry]
       t << "replace: olcLimits\n#{@property_flush[:limits].collect { |x| "olcLimits: #{x}" }.join("\n")}\n-\n" if @property_flush[:limits]


### PR DESCRIPTION
This PR is an attempt to fix the handling of syncrepl within the puppet module and add some documentation to the way it should work.

It is less than ideal, but it does work for us.

The changes to the code allow a consumer to be promoted to a provider safely and smoothly.

We are using under CentOS 7 with the https://symas.com/ rpm due to the lack of support of openldap from RHEL.

The underlining issue which this attempts to resolve, is that once a consumer or slave database has been create there is no way to clear the syncrepl details and promote it to master, 

I guess in theory you could use mirror/multi-master mode and change the masters around, but in our case we don't want the added complexity of having multiple master and wish to have one source of truth and should the master fail manually select a slave to master and move any other consumers/slaves onto the new master.

I'm not sure this is the right way to do this, but I was trying to work out the "Don't Care" and "Nothing" issue that exsists within puppet. 