### PR TITLE
Add management of TLS_MOZNSS_COMPATIBILITY to ldap.conf

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,7 +36,7 @@ class openldap::client(
   Optional[Stdlib::Absolutepath] $tls_cacertdir = undef,
   $tls_checkpeer                                = undef,
   $tls_reqcert                                  = undef,
-  Optional[Enum['on', 'true', 'yes', 'off', 'false', 'no']] $tls_moznss_compatibility = undef,  # lint:ignore:quoted_booleans
+  Optional[Enum['absent', 'on', 'true', 'yes', 'off', 'false', 'no']] $tls_moznss_compatibility = undef,  # lint:ignore:quoted_booleans
 
   # SASL Options
   $sasl_mech            = undef,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,6 +36,7 @@ class openldap::client(
   Optional[Stdlib::Absolutepath] $tls_cacertdir = undef,
   $tls_checkpeer                                = undef,
   $tls_reqcert                                  = undef,
+  Optional[Enum['on', 'true', 'yes', 'off', 'false', 'no']] $tls_moznss_compatibility = undef,  # lint:ignore:quoted_booleans
 
   # SASL Options
   $sasl_mech            = undef,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,7 +36,7 @@ class openldap::client(
   Optional[Stdlib::Absolutepath] $tls_cacertdir = undef,
   $tls_checkpeer                                = undef,
   $tls_reqcert                                  = undef,
-  Variant[Openldap::Tls_moznss_compatibility, 'absent', Undef] $tls_moznss_compatibility = undef,
+  Optional[Openldap::Tls_moznss_compatibility] $tls_moznss_compatibility = undef,
 
   # SASL Options
   $sasl_mech            = undef,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,7 +36,7 @@ class openldap::client(
   Optional[Stdlib::Absolutepath] $tls_cacertdir = undef,
   $tls_checkpeer                                = undef,
   $tls_reqcert                                  = undef,
-  Optional[Enum['absent', 'on', 'true', 'yes', 'off', 'false', 'no']] $tls_moznss_compatibility = undef,  # lint:ignore:quoted_booleans
+  Variant[Openldap::Tls_moznss_compatibility, 'absent', Undef] $tls_moznss_compatibility = undef,
 
   # SASL Options
   $sasl_mech            = undef,

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -206,6 +206,7 @@ class openldap::client::config {
     $tls_cacert,
     $tls_cacertdir,
     $tls_reqcert,
+    $tls_moznss_compatibility,
     $sasl_mech,
     $sasl_realm,
     $sasl_authcid,

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -133,6 +133,11 @@ class openldap::client::config {
     'absent' => 'rm TLS_REQCERT',
     default  => "set TLS_REQCERT ${::openldap::client::tls_reqcert}",
   }
+  $tls_moznss_compatibility = $::openldap::client::tls_moznss_compatibility ? {
+    undef    => undef,
+    'absent' => 'rm TLS_MOZNSS_COMPATIBILITY',
+    default  => "set TLS_MOZNSS_COMPATIBILITY ${::openldap::client::tls_moznss_compatibility}",
+  }
   $sasl_mech = $::openldap::client::sasl_mech ? {
     undef   => undef,
     default => "set SASL_MECH ${::openldap::client::sasl_mech}",

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -641,6 +641,7 @@ describe 'openldap::client::config' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
         case facts[:osfamily]
         when 'Debian'
           it {

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -634,6 +634,27 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with a valid tls_moznss_compatibility set' do
+        let :pre_condition do
+          "class {'openldap::client': tls_moznss_compatibility => 'true', }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        case facts[:osfamily]
+        when 'Debian'
+          it {
+            is_expected.to contain_augeas('ldap.conf').with(incl: '/etc/ldap/ldap.conf',
+                                                            changes: ['set TLS_MOZNSS_COMPATIBILITY true'])
+          }
+        when 'RedHat'
+          it {
+            is_expected.to contain_augeas('ldap.conf').with(incl: '/etc/openldap/ldap.conf',
+                                                            changes: ['set TLS_MOZNSS_COMPATIBILITY true'])
+          }
+        end
+      end
+
       context 'with sasl options set' do
         let :pre_condition do
           "class {'openldap::client':

--- a/spec/classes/openldap_client_config_spec.rb
+++ b/spec/classes/openldap_client_config_spec.rb
@@ -656,6 +656,28 @@ describe 'openldap::client::config' do
         end
       end
 
+      context 'with tls_moznss_compatibility being removed' do
+        let :pre_condition do
+          "class {'openldap::client': tls_moznss_compatibility => 'absent', }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::client::config') }
+        it { is_expected.to contain_augeas('ldap.conf') }
+        case facts[:osfamily]
+        when 'Debian'
+          it {
+            is_expected.to contain_augeas('ldap.conf').with(incl: '/etc/ldap/ldap.conf',
+                                                            changes: ['rm TLS_MOZNSS_COMPATIBILITY'])
+          }
+        when 'RedHat'
+          it {
+            is_expected.to contain_augeas('ldap.conf').with(incl: '/etc/openldap/ldap.conf',
+                                                            changes: ['rm TLS_MOZNSS_COMPATIBILITY'])
+          }
+        end
+      end
+
       context 'with sasl options set' do
         let :pre_condition do
           "class {'openldap::client':

--- a/types/tls_moznss_compatibility.pp
+++ b/types/tls_moznss_compatibility.pp
@@ -1,0 +1,2 @@
+# The list of possible values for TLS_MOZNSS_COMPATIBILITY based on the man page
+type Openldap::Tls_moznss_compatibility = Enum['on', 'true', 'yes', 'off', 'false', 'no']  # lint:ignore:quoted_booleans

--- a/types/tls_moznss_compatibility.pp
+++ b/types/tls_moznss_compatibility.pp
@@ -1,2 +1,2 @@
-# The list of possible values for TLS_MOZNSS_COMPATIBILITY based on the man page
-type Openldap::Tls_moznss_compatibility = Enum['on', 'true', 'yes', 'off', 'false', 'no']  # lint:ignore:quoted_booleans
+# The list of possible values TLS_MOZNSS_COMPATIBILITY can have (based on the man page), and an 'absent' (a puppet directive to remove an existing declaration).
+type Openldap::Tls_moznss_compatibility = Enum['on', 'true', 'yes', 'off', 'false', 'no', 'absent']  # lint:ignore:quoted_booleans


### PR DESCRIPTION
This adds management of 'TLS_MOZNSS_COMPATIBILITY'.

Enum'ed list is pulled from the ldap.conf man page.