### PR TITLE
add insensitive case olc database

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -36,7 +36,7 @@ Puppet::Type.
       paragraph.gsub("\n ", "").split("\n").collect do |line|
         case line
         when /^olcDatabase: /
-          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay|ldap)$/).captures
+          index, backend = line.match(/^olcDatabase: \{(\d+)\}(bdb|hdb|mdb|monitor|config|relay|ldap)$/i).captures
         when /^olcDbDirectory: /
           directory = line.split(' ')[1]
         when /^olcRootDN: /

--- a/spec/unit/puppet/type/openldap_database_spec.rb
+++ b/spec/unit/puppet/type/openldap_database_spec.rb
@@ -51,7 +51,7 @@ describe Puppet::Type.type(:openldap_database) do
     end
 
     describe 'backend' do
-      ['bdb', 'hdb', 'mdb', 'monitor', 'config', 'relay', 'ldap'].each do |b|
+      ['bdb', 'hdb', 'mdb', 'monitor', 'Monitor', 'config', 'relay', 'ldap'].each do |b|
         it "should support #{b} as a value for backend" do
           expect { described_class.new(name: 'foo', backend: b) }.not_to raise_error
         end


### PR DESCRIPTION
Hi,

We have this fix since a long time I don't know why it's not reported here.

Without this fix we have an issue, the match return nil and the captures method fail:
```
Debug: Prefetching olc resources for openldap_database
Debug: Executing: '/usr/sbin/slapcat -b cn=config -o ldif-wrap=no -H ldap:///???(|(olcDatabase=monitor)(olcDatabase={0}config)(&(objectClass=olcDatabaseConfig)(|(objectClass=olcBdbConfig)(objectClass=olcHdbConfig)(objectClass=olcMdbConfig)(objectClass=olcMonitorConfig)(objectClass=olcRelayConfig)(objectClass=olcLDAPConfig))))'
Error: Could not prefetch openldap_database provider 'olc': undefined method `captures' for nil:NilClass
Debug: Storing state
```