### PR TITLE
Fix emtpy suffix error and add lastbind objectClass

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -104,6 +104,9 @@ Puppet::Type.
       if backend.match(/config/i) and !suffix
         suffix = "cn=#{backend}"
       end
+      if !suffix
+        next
+      end
       new(
         :ensure          => :present,
         :name            => suffix,
@@ -126,7 +129,7 @@ Puppet::Type.
         :limits          => limits,
         :security        => security
       )
-    end
+    end.compact
   end
 
   def self.prefetch(resources)

--- a/lib/puppet/provider/openldap_overlay/olc.rb
+++ b/lib/puppet/provider/openldap_overlay/olc.rb
@@ -98,6 +98,8 @@ Puppet::Type.
       t << "objectClass: olcSmbK5PwdConfig\n"
     when 'sssvlv'
       t << "objectClass: olcSssVlvConfig\n"
+    when 'lastbind'
+      t << "objectClass: olcLastBindConfig\n"
     end
     t << "olcOverlay: #{resource[:overlay]}\n"
     if resource[:options]


### PR DESCRIPTION
# Empty suffix error
After upgrading module from 1.6.1 to 2.0.0 I hit the following issue:
```
Error: Could not prefetch openldap_database provider 'olc': No resource and no name in property hash in olc instance
Error: Failed to apply catalog: No resource and no name in property hash in olc instance
```

It was cause by the addition of ldap to the list of databases retrieved by the `openldap_database` provider:
```git
-    databases = slapcat("(|(olcDatabase=monitor)(olcDatabase={0}config)(&(objectClass=olcDatabaseConfig)(|(objectClass=olcBdbConfig)(objectClass=olcHdbConfig)(objectClass=olcMdbConfig)(objectClass=olcMonitorConfig)(objectClass=olcRelayConfig))))")
+    databases = slapcat("(|(olcDatabase=monitor)(olcDatabase={0}config)(&(objectClass=olcDatabaseConfig)(|(objectClass=olcBdbConfig)(objectClass=olcHdbConfig)(objectClass=olcMdbConfig)(objectClass=olcMonitorConfig)(objectClass=olcRelayConfig)(objectClass=olcLDAPConfig))))")
```

We have a database with ldap that doesn't set olcSuffix attribute, adding nil entries to the list of databases, and breaking `self.prefetch`.

I've fixed that issue by assuming that some databases could not provide a suffix, removing those elements from the array.


# lastbind
I've also added support for lastbind overlay during the creation of the resource `openldap_overlay`.