### PR TITLE
Unbreak with Puppet 7.4.0 / 6.21.0 on Debian 10

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,16 +10,8 @@ class openldap::server::service {
     default => stopped,
   }
 
-  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-    # Puppet4 fallback to init provider which does not support enableable
-    $provider = 'debian'
-  } else {
-    $provider = undef
-  }
-
   service { $::openldap::server::service:
     ensure    => $ensure,
-    provider  => $provider,
     enable    => $::openldap::server::enable,
     hasstatus => $::openldap::server::service_hasstatus,
   }


### PR DESCRIPTION
After updating Puppet from 7.3.0 to 7.4.0, I started to see failures to apply catalog on a Debian 10 node:

```sh-session
root@node ~ # puppet agent -t --noop
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Applying configuration version 'production-51dc531'
Error: /Stage[main]/Openldap::Server::Service/Service[slapd]: Provider debian is not functional on this host
Notice: /Stage[main]/Openldap::Server::Slapdconf/File[/etc/ldap/slapd.d]: Dependency Service[slapd] has failures: true
Warning: /Stage[main]/Openldap::Server::Slapdconf/File[/etc/ldap/slapd.d]: Skipping because of failed dependencies
Warning: /Stage[main]/Openldap::Server::Slapdconf/Openldap::Server::Globalconf[TLSCertificate]/Openldap_global_conf[TLSCertificate]: Skipping because of failed dependencies
Warning: /Stage[main]/Openldap::Server::Slapdconf/Openldap::Server::Database[dc=my-domain,dc=com]/Openldap_database[dc=my-domain,dc=com]: Skipping because of failed dependencies
[...]
```

Puppet might have changed the dependencies on the `debian` provider which leads to this error on this system, but since according to comment, the usage of the `debian` provider is a workaround for users of Puppet 4, adjust the condition to not trigger it when Puppet 5 or better.