### PR TITLE
Don't delete temporary file before using it

### DIFF
--- a/lib/puppet/provider/openldap_global_conf/olc.rb
+++ b/lib/puppet/provider/openldap_global_conf/olc.rb
@@ -78,12 +78,13 @@ Puppet::Type.
       t << "add: olc#{resource[:name]}\n"
       t << "olc#{resource[:name]}: #{resource[:value]}\n"
     end
-    t.close
     Puppet.debug(File.read(t.path))
     begin
       ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{File.read t.path}\nError message: #{e.message}"
+    ensure
+      t.close
     end
     @property_hash[:ensure] = :present
   end
@@ -99,12 +100,13 @@ Puppet::Type.
     else
       t << "delete: olc#{name}\n"
     end
-    t.close
     Puppet.debug(File.read(t.path))
     begin
       ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{File.read t.path}\nError message: #{e.message}"
+    ensure
+      t.close
     end
     @property_hash.clear
   end
@@ -139,12 +141,13 @@ Puppet::Type.
       t << "replace: olc#{name}\n"
       t << "olc#{name}: #{value}\n"
     end
-    t.close
     Puppet.debug(File.read(t.path))
     begin
       ldapmodify(t.path)
     rescue Exception => e
       raise Puppet::Error, "LDIF content:\n#{File.read t.path}\nError message: #{e.message}"
+    ensure
+      t.close
     end
     @property_hash[:value] = value
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I encountered an LDAP error 80 (`LDAP_OTHER`) whilst adding SSL certificates:
```
 class { 'openldap::server':
        ssl_cert   => '/etc/ssl/certs/foo.com.crt',
        ssl_key    => '/etc/ssl/private/foo.com.key',
        ssl_ca     => '/etc/ssl/certs/foo.com.ca-bundle',
    }
```

#### This Pull Request (PR) fixes the following issues
Doesn't delete temporary files before they're used
