### PR TITLE
Remove creation of access rules on a new database

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -275,18 +275,20 @@ Puppet::Type
     t << "olcSyncUseSubentry: #{resource[:syncusesubentry]}\n" if resource[:syncusesubentry]
     t << "#{resource[:limits].map { |x| "olcLimits: #{x}" }.join("\n")}\n" if resource[:limits] && !resource[:limits].empty?
     t << "#{resource[:security].map { |k, v| "olcSecurity: #{k}=#{v}" }.join("\n")}\n" if resource[:security] && !resource[:security].empty?
-    t << "olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break\n"
-    admin = resource[:rootdn] || "cn=admin,#{resource[:suffix]}"
-    t << "olcAccess: to attrs=userPassword\n"
-    t << "  by self write\n"
-    t << "  by anonymous auth\n"
-    t << "  by dn=\"#{admin}\" write\n"
-    t << "  by * none\n"
-    t << "olcAccess: to dn.base=\"\" by * read\n"
-    t << "olcAccess: to *\n"
-    t << "  by self write\n"
-    t << "  by dn=\"#{admin}\" write\n"
-    t << "  by * read\n"
+    if resource[:initdb] == :true
+      t << "olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break\n"
+      admin = resource[:rootdn] || "cn=admin,#{resource[:suffix]}"
+      t << "olcAccess: to attrs=userPassword\n"
+      t << "  by self write\n"
+      t << "  by anonymous auth\n"
+      t << "  by dn=\"#{admin}\" write\n"
+      t << "  by * none\n"
+      t << "olcAccess: to dn.base=\"\" by * read\n"
+      t << "olcAccess: to *\n"
+      t << "  by self write\n"
+      t << "  by dn=\"#{admin}\" write\n"
+      t << "  by * read\n"
+    end
     t.close
     Puppet.debug(File.read(t.path))
     begin


### PR DESCRIPTION
#### Pull Request (PR) description
I've made a 2-commit series that removes ACLs from a database creation.

#32 introduced these ACLs based on the debian-of-2014 configuration, adding basic ACLs to brand new databases when the database is first created.  #316 points out that, if you are spinning up a database from scratch and have your own access rules in play, this will create conflict between ACL rules you declare and ACL rules that poof, appear out of nowhere.  The rules themselves don't make a lot of sense (being so old and debian-specific), and may not even mesh with your schema.  And if they were what you wanted, you should be declaring those rules anyway.

Commit 1 does what @scorillo suggests, wrapping the ACL creation in an 'if initdb'.  This, to me, is the minimum change.  If I've declared `initdb => false' then I've said I want no DB initialization, so don't go adding ACLs.  These ACLs also create a mess when you are trying to do a chained database with initdb=false, which wouldn't/shouldn't have these ACLs (which is how I discovered this).  So by -some- means these should not be mandatory ACLs.

Commit 2 does what @smortex suggests and just removes the ACLs altogether.  This is the more complete change.  By my prior thought, there's no reasonable reason for these ACLs to spring into existence only to be a collision later.  BUT, if we're wrong, you can revert commit 2 while still leaving the optionality of commit 1 in place.

TECHNICALLY this might be a breaking change as it removes an ACL-creating behavior.  I've not spun a new DB in a while and all mine are `initdb=false` anyway, but honestly I can't fathom anyone who'd be relying on ACLs created this way.

#### This Pull Request (PR) fixes the following issues
Fixes #316 